### PR TITLE
Switch `file` parameter to be optional

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -29,8 +29,8 @@ commands:
           name: Upload Coverage Results
           command: |
             bash <(curl -s https://codecov.io/bash) \
-              -F << parameters.flags >> \
               -f << parameters.file >> \
               -n << parameters.upload_name >> \
               -t << parameters.token >> \
               -y << parameters.conf >> \
+              -F << parameters.flags >> \


### PR DESCRIPTION
This switches the `file` parameter to be optional.  We will need to wait for the `bash` uploader to be updated so that it takes in optional parameters.