### PR TITLE
Move flags flag to end of bash command to avoid conflict

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -29,8 +29,8 @@ commands:
           name: Upload Coverage Results
           command: |
             bash <(curl -s https://codecov.io/bash) \
-              -F << parameters.flags >> \
               -f << parameters.file >> \
               -n << parameters.upload_name >> \
               -t << parameters.token >> \
               -y << parameters.conf >> \
+              -F << parameters.flags >> \


### PR DESCRIPTION
PTAL @hootener 

For users that aren't using the `flags` feature, the bash uploader is trying to parse `-f` as a flag.  This is messing with the rest of the arguments.  By moving it to the end, we avoid that issue, but the bash uploader will eventually need to be updated