### PR TITLE
Fix execution for alpine

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -32,7 +32,7 @@ commands:
             - run:
                 name: Upload Coverage Results
                 command: |
-                  bash <(curl -s https://codecov.io/bash) \
+                  curl -s https://codecov.io/bash | bash -s - \
                     -f << parameters.file >> \
                     -n << parameters.upload_name >> \
                     -t << parameters.token >> \
@@ -45,7 +45,7 @@ commands:
             - run:
                 name: Upload Coverage Results
                 command: |
-                  bash <(curl -s https://codecov.io/bash) \
+                  curl -s https://codecov.io/bash | bash -s - \
                     -n << parameters.upload_name >> \
                     -t << parameters.token >> \
                     -y << parameters.conf >> \


### PR DESCRIPTION
Fixes #8

Still requires that `bash` is installed with `apk --update add bash`.