### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -2,7 +2,10 @@ version: 2.1
 
 description: >
   Upload your coverage reports to Codecov without dealing with complex configurations. This orb helps you get coverage results quickly so that you can breathe easier and commit your code with confidence.
-  Repo: https://github.com/codecov/codecov-circleci-orb
+
+display:
+  source_url: https://github.com/codecov/codecov-circleci-orb
+  home_url: https://codecov.io/
 
 commands:
   upload:


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.