### PR TITLE
Update config file parameter, default value

### DIFF
--- a/orb.yml
+++ b/orb.yml
@@ -13,7 +13,7 @@ commands:
       conf:
         description: Used to specify the location of the .codecov.yml config file
         type: string
-        default: ".codecov.yml"
+        default: "codecov.yml"
       file:
         description: Path to the code coverage data file to upload.
         type: string
@@ -49,7 +49,7 @@ commands:
                     -f "<< parameters.file >>" \
                     -t "<< parameters.token >>" \
                     -n "<< parameters.upload_name >>" \
-                    -y "<< parameters.conf >>" \
+                    -y << parameters.conf >> \
                     -F "<< parameters.flags >>" \
                     -Z || echo 'Codecov upload failed'
                 when: << parameters.when >>
@@ -62,7 +62,7 @@ commands:
                   curl -s << parameters.url >> | bash -s -- \
                     -t "<< parameters.token >>" \
                     -n "<< parameters.upload_name >>" \
-                    -y "<< parameters.conf >>" \
+                    -y << parameters.conf >> \
                     -F "<< parameters.flags >>" \
                     -Z || echo 'Codecov upload failed'
                 when: << parameters.when >>


### PR DESCRIPTION
Fixes #31: Update default config file name to `codecov.yml`
Fixes #33: Remove quotes from config file parameter to allow paths outside of `./`