### PR TITLE
[semver:patch] Bump to 1.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.sw[op]
+node_modules/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-circleci-orb",
-  "version": "1.0.6",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-circleci-orb",
-  "version": "1.0.5",
+  "version": "1.1.1",
   "description": "Codecov CircleCI Orb",
   "main": "index.js",
   "devDependencies": {


### PR DESCRIPTION
Bump to 1.1.1 due to security vulnerability on `lodash`
https://github.com/advisories/GHSA-p6mc-m468-83gw
