### PR TITLE
Fixed bash command failure due to unescaped line break

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -42,7 +42,7 @@ commands:
                 name: Upload Coverage Results
                 command: |
                   curl -sS << parameters.url >> | bash -s -- \
-                    -Q "codecov-circleci-orb-1.1.2"
+                    -Q "codecov-circleci-orb-1.1.2" \
                     -f "<< parameters.file >>" \
                     -t "<< parameters.token >>" \
                     -n "<< parameters.upload_name >>" \
@@ -56,7 +56,7 @@ commands:
                 name: Upload Coverage Results
                 command: |
                   curl -sS << parameters.url >> | bash -s -- \
-                    -Q "codecov-circleci-orb-1.1.2"
+                    -Q "codecov-circleci-orb-1.1.2" \
                     -t "<< parameters.token >>" \
                     -n "<< parameters.upload_name >>" \
                     -F "<< parameters.flags >>" \


### PR DESCRIPTION
I think this change causes bash command error.
https://github.com/codecov/codecov-circleci-orb/pull/57/files#diff-73bdc7f6ecdb2576f0a66a84f59829dbacbad92b6a46ffe50374f8707139fdb1R45

I forked your repo and fixed it, please accept this if it is OK.