### PR TITLE
Retry to alleviate for transient failures during upload

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -65,9 +65,9 @@ commands:
             - run:
                 name: Upload Coverage Results
                 command: |
-                  curl -sS << parameters.url >> | bash -s -- \
-                    --retry << parameters.retry >> \
-                    --retry-delay << parameters.retry-delay >> \
+                  curl -sS << parameters.url >> \
+                    --retry << parameters.retry >> 
+                    --retry-delay << parameters.retry-delay >> | bash -s -- \
                     -Q "codecov-circleci-orb-1.1.2" \
                     -t "<< parameters.token >>" \
                     -n "<< parameters.upload_name >>" \

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -18,6 +18,14 @@ commands:
         description: Flag the upload to group coverage metrics (e.g. unittests | integration | ui,chrome)
         type: string
         default: ""
+      retry:
+        description: Retry this number of times before giving up
+        type: integer
+        default: 4
+      retry-delay:
+        description: Seconds to wait before nexxt retry attempt
+        type: integer
+        default: 15
       token:
         description: Set the private repository token as the value of the variable CODECOV_TOKEN using CircleCI Environment Variables.
         type: string
@@ -42,6 +50,8 @@ commands:
                 name: Upload Coverage Results
                 command: |
                   curl -sS << parameters.url >> | bash -s -- \
+                    --retry << parameters.retry >> \
+                    --retry-delay << parameters.retry-delay >> \
                     -Q "codecov-circleci-orb-1.1.2" \
                     -f "<< parameters.file >>" \
                     -t "<< parameters.token >>" \
@@ -56,6 +66,8 @@ commands:
                 name: Upload Coverage Results
                 command: |
                   curl -sS << parameters.url >> | bash -s -- \
+                    --retry << parameters.retry >> \
+                    --retry-delay << parameters.retry-delay >> \
                     -Q "codecov-circleci-orb-1.1.2" \
                     -t "<< parameters.token >>" \
                     -n "<< parameters.upload_name >>" \

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -19,9 +19,9 @@ commands:
         type: string
         default: ""
       retry:
-        description: Retry this number of times before giving up
+        description: If a transient error is returned when curl tries to perform a transfer, it will retry this number of times before giving up.
         type: integer
-        default: 4
+        default: 0
       retry-delay:
         description: Seconds to wait before next retry attempt
         type: integer

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -49,9 +49,9 @@ commands:
             - run:
                 name: Upload Coverage Results
                 command: |
-                  curl -sS << parameters.url >> \
-                    --retry << parameters.retry >> 
-                    --retry-delay << parameters.retry-delay >> | bash -s -- \
+                  curl -sS --retry << parameters.retry >> \
+                    --retry-delay << parameters.retry-delay >> \
+                    << parameters.url >> | bash -s -- \
                     -Q "codecov-circleci-orb-1.1.2" \
                     -f "<< parameters.file >>" \
                     -t "<< parameters.token >>" \
@@ -65,9 +65,9 @@ commands:
             - run:
                 name: Upload Coverage Results
                 command: |
-                  curl -sS << parameters.url >> \
-                    --retry << parameters.retry >> 
-                    --retry-delay << parameters.retry-delay >> | bash -s -- \
+                  curl -sS --retry << parameters.retry >> \
+                    --retry-delay << parameters.retry-delay >> \
+                    << parameters.url >> | bash -s -- \
                     -Q "codecov-circleci-orb-1.1.2" \
                     -t "<< parameters.token >>" \
                     -n "<< parameters.upload_name >>" \

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -49,9 +49,9 @@ commands:
             - run:
                 name: Upload Coverage Results
                 command: |
-                  curl -sS << parameters.url >> | bash -s -- \
-                    --retry << parameters.retry >> \
-                    --retry-delay << parameters.retry-delay >> \
+                  curl -sS << parameters.url >> \
+                    --retry << parameters.retry >> 
+                    --retry-delay << parameters.retry-delay >> | bash -s -- \
                     -Q "codecov-circleci-orb-1.1.2" \
                     -f "<< parameters.file >>" \
                     -t "<< parameters.token >>" \

--- a/src/orb.yml
+++ b/src/orb.yml
@@ -23,7 +23,7 @@ commands:
         type: integer
         default: 4
       retry-delay:
-        description: Seconds to wait before nexxt retry attempt
+        description: Seconds to wait before next retry attempt
         type: integer
         default: 15
       token:


### PR DESCRIPTION
- The curl command can fail sporadically due to network hiccups or third party outages. This can cause a CI step to fail and becomes a false negative. The two new `retry` and `retry_delay` helps setting a number of attempts to retry at a given cadence before failing.