### PR TITLE
Add checksum validation for the codecov bash uploader

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -30,18 +30,38 @@ commands:
         description: Custom url to submit the codecov result. Default to "https://codecov.io/bash"
         type: string
         default: "https://codecov.io/bash"
+      validate_url:
+        description: Validate the url before submitting the codecov result. https://docs.codecov.io/docs/about-the-codecov-bash-uploader#validating-the-bash-script
+        type: boolean
+        default: true
       when:
         description: When should this step run?
         type: string
         default: "always"
     steps:
+      - run:
+          name: Download Codecov Bash Uploader
+          command: curl -s << parameters.url >> > codecov
+          when: << parameters.when >>
+      - when:
+          condition: << parameters.validate_url >>
+          steps:
+            - run:
+                name: Validate Codecov Bash Uploader
+                command: |
+                  VERSION=$(grep 'VERSION=\".*\"' codecov | cut -d'"' -f2);
+                  for i in 1 256 512
+                  do
+                    diff <(shasum -a $i codecov) <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/$VERSION/SHA${i}SUM)
+                  done
+                when: << parameters.when >>
       - when:
           condition: << parameters.file >>
           steps:
             - run:
                 name: Upload Coverage Results
                 command: |
-                  curl -sS << parameters.url >> | bash -s -- \
+                  cat codecov | bash -s -- \
                     -Q "codecov-circleci-orb-1.1.2" \
                     -f "<< parameters.file >>" \
                     -t "<< parameters.token >>" \
@@ -55,7 +75,7 @@ commands:
             - run:
                 name: Upload Coverage Results
                 command: |
-                  curl -sS << parameters.url >> | bash -s -- \
+                  cat codecov | bash -s -- \
                     -Q "codecov-circleci-orb-1.1.2" \
                     -t "<< parameters.token >>" \
                     -n "<< parameters.upload_name >>" \

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -52,7 +52,7 @@ commands:
                   VERSION=$(grep 'VERSION=\".*\"' codecov | cut -d'"' -f2);
                   for i in 1 256 512
                   do
-                    diff <(shasum -a $i codecov) <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/$VERSION/SHA${i}SUM)
+                    shasum -a $i -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM)
                   done
                 when: << parameters.when >>
       - when:


### PR DESCRIPTION
resolves: #68 

Adds an optional (default true) step to perform checksum validation on the Codecov bash uploader.