### PR TITLE
[semver:patch] Update validation regex and add shasum flexibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.5
+**Fixes**
+- #78 Update validation regex and add shasum flexibility
+
 ## 1.1.4
 **Features**
 None

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-circleci-orb",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-circleci-orb",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "description": "Codecov CircleCI Orb",
   "main": "index.js",
   "devDependencies": {

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -48,7 +48,7 @@ commands:
             - run:
                 name: Validate Codecov Bash Uploader
                 command: |
-                  VERSION=$(grep 'VERSION=\".*\"' codecov | cut -d'"' -f2);
+                  VERSION=$(grep 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
                   for i in 1 256 512
                   do
                     shasum -a $i -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM) ||

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -51,7 +51,8 @@ commands:
                   VERSION=$(grep 'VERSION=\".*\"' codecov | cut -d'"' -f2);
                   for i in 1 256 512
                   do
-                    shasum -a $i -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM)
+                    shasum -a $i -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM) ||
+                    shasum -a $i -c <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM)
                   done
       - when:
           condition: << parameters.file >>


### PR DESCRIPTION
Removes the need for `VERSION` and pegs to `production`

fixes https://github.com/codecov/codecov-circleci-orb/issues/77#issuecomment-820912091