### PR TITLE
[semver:patch] Update bash curling best practices and bump to 1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.6
+**Fixes**
+- #81 Update bash script with best practices
+
 ## 1.1.5
 **Fixes**
 - #78 Update validation regex and add shasum flexibility

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 1.1.6
 **Fixes**
 - #81 Update bash script with best practices
+- #82 Reduce the code in the orb to DRY
 
 ## 1.1.5
 **Fixes**

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # codecov-circleci-orb
 
-## Latest version 1.1.4
+## Latest version 1.1.6
 
 [![codecov.io](https://codecov.io/github/codecov/codecov-circleci-orb/coverage.svg?branch=master)](https://codecov.io/github/codecov/codecov-circleci-orb)
 [![Circle CI](https://circleci.com/gh/codecov/codecov-circleci-orb.png?style=badge)](https://circleci.com/gh/codecov/codecov-circleci-orb)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-circleci-orb",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "description": "Codecov CircleCI Orb",
   "main": "index.js",
   "devDependencies": {

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -40,7 +40,7 @@ commands:
     steps:
       - run:
           name: Download Codecov Bash Uploader
-          command: curl -s << parameters.url >> > codecov
+          command: curl -fLso codecov << parameters.url >>
           when: << parameters.when >>
       - when:
           condition: << parameters.validate_url >>
@@ -52,7 +52,7 @@ commands:
                   for i in 1 256 512
                   do
                     shasum -a $i -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM) ||
-                    shasum -a $i -c <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM)
+                    shasum -a $i -c <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM | grep -w "codecov")
                   done
       - when:
           condition: << parameters.file >>


### PR DESCRIPTION
Update the bash script download with best practices