### PR TITLE
[semver:patch] Add support for Windows builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
     steps:
       - checkout
       - node/install-npm
+      - run: npm install
       - run: npm test
   test-codecov-orb:
     parameters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,6 +69,8 @@ jobs:
     parameters:
       os:
         type: executor
+      using_windows:
+        type: boolean
     executor: << parameters.os >>
     steps:
       - checkout
@@ -76,17 +78,14 @@ jobs:
           at: .
       - codecov/upload:
           flags: backend
-          using_windows:
-            - equal: [ 'windows', << parameters.os >> ]
+          using_windows: << parameters.using_windows >>
       - codecov/upload:
           file: coverage/coverage-final.json
           flags: frontend
-          using_windows:
-            - equal: [ 'windows', << parameters.os >> ]
+          using_windows: << parameters.using_windows >>
           xtra_args: -v -Z
 
 workflows:
-  # This `lint-pack_validate_publish-dev` workflow will run on any commit.
   test-pack:
     unless: << pipeline.parameters.run-integration-tests >>
     jobs:
@@ -123,7 +122,16 @@ workflows:
       - test-codecov-orb:
           matrix:
             parameters:
-              os: [linux, macos, windows]
+              os: [linux, macos]
+              using_windows: false
+          requires:
+            - test-backend
+            - test-frontend
+
+      - test-codecov-orb:
+          parameters:
+            os: windows
+            using_windows: true
           requires:
             - test-backend
             - test-frontend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,11 +76,13 @@ jobs:
           at: .
       - codecov/upload:
           flags: backend
-          using_windows: << parameters.os >> == 'windows'
+          using_windows:
+            - equal: [ 'windows', << parameters.os >> ]
       - codecov/upload:
           file: coverage/coverage-final.json
           flags: frontend
-          using_windows: << parameters.os >> == 'windows'
+          using_windows:
+            - equal: [ 'windows', << parameters.os >> ]
           xtra_args: -v -Z
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,14 +76,29 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
-      - codecov/upload:
-          flags: backend
-          using_windows: << parameters.using_windows >>
-      - codecov/upload:
-          file: coverage/coverage-final.json
-          flags: frontend
-          using_windows: << parameters.using_windows >>
-          xtra_args: -v -Z
+      - when:
+          condition: << parameters.os >> != 'windows'
+          steps:
+            - codecov/upload:
+                flags: backend
+                using_windows: false
+            - codecov/upload:
+                file: coverage/coverage-final.json
+                flags: frontend
+                using_windows: false
+                xtra_args: -v -Z
+      - when:
+          condition: << parameters.os >> == 'windows'
+          steps:
+            - codecov/upload:
+                flags: backend
+                using_windows: true
+            - codecov/upload:
+                file: coverage/coverage-final.json
+                flags: frontend
+                using_windows: true
+                xtra_args: -v -Z
+
 
 workflows:
   test-pack:
@@ -120,25 +135,9 @@ workflows:
       - test-backend
       - test-frontend
       - test-codecov-orb:
-          parameters:
-            os: linux
-            using_windows: false
-          requires:
-            - test-backend
-            - test-frontend
-
-      - test-codecov-orb:
-          parameters:
-            os: macos
-            using_windows: true
-          requires:
-            - test-backend
-            - test-frontend
-
-      - test-codecov-orb:
-          parameters:
-            os: windows
-            using_windows: true
+          matrix:
+            parameters:
+              os: [linux, macos, windows]
           requires:
             - test-backend
             - test-frontend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
           file: coverage/coverage-final.json
           flags: frontend
           using_windows: << parameters.using_windows >>
-          xtra_args: -v&-Z
+          xtra_args: -v=$true&-Z=$true
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
           file: coverage/coverage-final.json
           flags: frontend
           using_windows: << parameters.using_windows >>
-          xtra_args: -v=$true&-Z=$true
+          xtra_args: -v -Z
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,8 +69,6 @@ jobs:
     parameters:
       os:
         type: executor
-      using_windows:
-        type: boolean
     executor: << parameters.os >>
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -83,7 +83,7 @@ jobs:
           file: coverage/coverage-final.json
           flags: frontend
           using_windows: << parameters.using_windows >>
-          xtra_args: -v -Z
+          xtra_args: -v&-Z
 
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,8 +50,6 @@ jobs:
       - python/install-packages:
           pkg-manager: pip
       - run: python3 -m pytest --junitxml=junit/test-results.xml --cov=src --cov-report=xml --cov-report=html test/unit
-      - store_artifacts:
-          path: coverage.xml
   test-frontend:
     executor: node
     steps:
@@ -59,8 +57,6 @@ jobs:
       - node/install-npm
       - run: npm install
       - run: npm test
-      - store_artifacts:
-          path: coverage/coverage-final.json
   test-codecov-orb:
     parameters:
       os:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,17 +75,6 @@ jobs:
       - attach_workspace:
           at: .
       - when:
-          condition: << parameters.os >> != 'windows'
-          steps:
-            - codecov/upload:
-                flags: backend
-                using_windows: false
-            - codecov/upload:
-                file: coverage/coverage-final.json
-                flags: frontend
-                using_windows: false
-                xtra_args: -v -Z
-      - when:
           condition: << parameters.os >> == 'windows'
           steps:
             - codecov/upload:
@@ -95,6 +84,17 @@ jobs:
                 file: coverage/coverage-final.json
                 flags: frontend
                 using_windows: true
+                xtra_args: -v -Z
+      - unless:
+          condition: << parameters.os >> == 'windows'
+          steps:
+            - codecov/upload:
+                flags: backend
+                using_windows: false
+            - codecov/upload:
+                file: coverage/coverage-final.json
+                flags: frontend
+                using_windows: false
                 xtra_args: -v -Z
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
       - attach_workspace:
           at: .
       - when:
-          condition: << parameters.os >> == windows
+          condition: << parameters.os.name >> == "windows"
           steps:
             - codecov/upload:
                 flags: backend
@@ -86,7 +86,7 @@ jobs:
                 using_windows: true
                 xtra_args: -v -Z
       - unless:
-          condition: << parameters.os >> == windows
+          condition: << parameters.os.name >> == "windows"
           steps:
             - codecov/upload:
                 flags: backend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,6 +122,7 @@ workflows:
       - test-frontend
       - test-codecov-orb:
           matrix:
+            alias: test-codecov-orb-non-windows
             parameters:
               os: [linux, macos]
               using_windows: [false]
@@ -130,6 +131,7 @@ workflows:
             - test-frontend
       - test-codecov-orb:
           matrix:
+            alias: test-codecov-orb-windows
             parameters:
               os: [windows]
               using_windows: [true]
@@ -148,4 +150,5 @@ workflows:
           publish-version-tag: false
           publish-token-variable: ORB_PUBLISH_TOKEN
           requires:
-            - test-codecov-orb
+            - test-codecov-orb-non-windows
+            - test-codecov-orb-windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,16 +119,23 @@ workflows:
     jobs:
       - test-backend
       - test-frontend
-      - test-codecov-orb:
-          matrix:
-            parameters:
-              os: [linux, macos]
-              using_windows: false
+      - test-codecov-orb-linux:
+          parameters:
+            os: linux
+            using_windows: false
           requires:
             - test-backend
             - test-frontend
 
-      - test-codecov-orb:
+      - test-codecov-orb-macos:
+          parameters:
+            os: macos
+            using_windows: true
+          requires:
+            - test-backend
+            - test-frontend
+
+      - test-codecov-orb-windows:
           parameters:
             os: windows
             using_windows: true
@@ -147,4 +154,6 @@ workflows:
           publish-version-tag: false
           publish-token-variable: ORB_PUBLISH_TOKEN
           requires:
-            - test-codecov-orb
+            - test-codecov-orb-linux
+            - test-codecov-orb-macos
+            - test-codecov-orb-windows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,6 @@ jobs:
     executor: << parameters.os >>
     steps:
       - checkout
-      -
       - codecov/upload:
           flags: backend
       - codecov/upload:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,8 +74,11 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
+      - run: |
+          echo << parameters.os >>
+          echo << parameters.os >>.name
       - when:
-          condition: << parameters.os.name >> == "windows"
+          condition: << parameters.os >> == "windows"
           steps:
             - codecov/upload:
                 flags: backend
@@ -86,7 +89,7 @@ jobs:
                 using_windows: true
                 xtra_args: -v -Z
       - unless:
-          condition: << parameters.os.name >> == "windows"
+          condition: << parameters.os >> == "windows"
           steps:
             - codecov/upload:
                 flags: backend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,8 @@ jobs:
       - python/install-packages:
           pkg-manager: pip
       - run: python3 -m pytest --junitxml=junit/test-results.xml --cov=src --cov-report=xml --cov-report=html test/unit
+      - store_artifacts:
+          path: coverage.xml
   test-frontend:
     executor: node
     steps:
@@ -57,12 +59,16 @@ jobs:
       - node/install-npm
       - run: npm install
       - run: npm test
+      - store_artifacts:
+          path: coverage/coverage-final.json
   test-codecov-orb:
     parameters:
       os:
         type: executor
     executor: << parameters.os >>
     steps:
+      - checkout
+      -
       - codecov/upload:
           flags: backend
       - codecov/upload:
@@ -75,8 +81,6 @@ workflows:
   test-pack:
     unless: << pipeline.parameters.run-integration-tests >>
     jobs:
-      - test-backend
-      - test-frontend
       - orb-tools/lint
       - orb-tools/pack
       - hold:
@@ -84,8 +88,6 @@ workflows:
           requires:
             - orb-tools/lint
             - orb-tools/pack
-            - test-backend
-            - test-frontend
 
       # release dev version of orb, for testing & possible publishing.
       # orb will be published as dev:alpha and dev:${CIRCLE_SHA1:0:7}.
@@ -107,13 +109,15 @@ workflows:
   integration-tests_deploy:
     when: << pipeline.parameters.run-integration-tests >>
     jobs:
-      # your integration test jobs go here: essentially, run all your orb's
-      # jobs and commands to ensure they behave as expected. or, run other
-      # integration tests of your choosing
+      - test-backend
+      - test-frontend
       - test-codecov-orb:
           matrix:
             parameters:
               os: [linux, macos, windows]
+          requires:
+            - test-backend
+            - test-frontend
 
       - orb-tools/dev-promote-prod-from-commit-subject:
           add-pr-comment: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,9 +76,11 @@ jobs:
           at: .
       - codecov/upload:
           flags: backend
+          using_windows: << parameters.os >> == 'windows'
       - codecov/upload:
           file: coverage/coverage-final.json
           flags: frontend
+          using_windows: << parameters.os >> == 'windows'
           xtra_args: -v -Z
 
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,4 +126,4 @@ workflows:
           publish-version-tag: false
           publish-token-variable: ORB_PUBLISH_TOKEN
           requires:
-            - integration-test
+            - test-codecov-orb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -122,7 +122,7 @@ workflows:
       - test-frontend
       - test-codecov-orb:
           parameters:
-            os: linux
+            os: [linux]
             using_windows: false
           requires:
             - test-backend
@@ -130,7 +130,7 @@ workflows:
 
       - test-codecov-orb:
           parameters:
-            os: macos
+            os: [macos]
             using_windows: false
           requires:
             - test-backend
@@ -138,7 +138,7 @@ workflows:
 
       - test-codecov-orb:
           parameters:
-            os: windows
+            os: [windows]
             using_windows: true
           requires:
             - test-backend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -121,25 +121,18 @@ workflows:
       - test-backend
       - test-frontend
       - test-codecov-orb:
-          parameters:
-            os: [linux]
-            using_windows: false
+          matrix:
+            parameters:
+              os: [linux, macos]
+              using_windows: [false]
           requires:
             - test-backend
             - test-frontend
-
       - test-codecov-orb:
-          parameters:
-            os: [macos]
-            using_windows: false
-          requires:
-            - test-backend
-            - test-frontend
-
-      - test-codecov-orb:
-          parameters:
-            os: [windows]
-            using_windows: true
+          matrix:
+            parameters:
+              os: [windows]
+              using_windows: [true]
           requires:
             - test-backend
             - test-frontend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,36 +69,21 @@ jobs:
     parameters:
       os:
         type: executor
+      using_windows:
+        type: boolean
     executor: << parameters.os >>
     steps:
       - checkout
       - attach_workspace:
           at: .
-      - run: |
-          echo << parameters.os >>
-          echo << parameters.os >>.name
-      - when:
-          condition: << parameters.os >> == "windows"
-          steps:
-            - codecov/upload:
-                flags: backend
-                using_windows: true
-            - codecov/upload:
-                file: coverage/coverage-final.json
-                flags: frontend
-                using_windows: true
-                xtra_args: -v -Z
-      - unless:
-          condition: << parameters.os >> == "windows"
-          steps:
-            - codecov/upload:
-                flags: backend
-                using_windows: false
-            - codecov/upload:
-                file: coverage/coverage-final.json
-                flags: frontend
-                using_windows: false
-                xtra_args: -v -Z
+      - codecov/upload:
+          flags: backend
+          using_windows: << parameters.using_windows >>
+      - codecov/upload:
+          file: coverage/coverage-final.json
+          flags: frontend
+          using_windows: << parameters.using_windows >>
+          xtra_args: -v -Z
 
 
 workflows:
@@ -136,9 +121,25 @@ workflows:
       - test-backend
       - test-frontend
       - test-codecov-orb:
-          matrix:
-            parameters:
-              os: [linux, macos, windows]
+          parameters:
+            os: linux
+            using_windows: false
+          requires:
+            - test-backend
+            - test-frontend
+
+      - test-codecov-orb:
+          parameters:
+            os: macos
+            using_windows: false
+          requires:
+            - test-backend
+            - test-frontend
+
+      - test-codecov-orb:
+          parameters:
+            os: windows
+            using_windows: true
           requires:
             - test-backend
             - test-frontend

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ workflows:
     jobs:
       - test-backend
       - test-frontend
-      - test-codecov-orb-linux:
+      - test-codecov-orb:
           parameters:
             os: linux
             using_windows: false
@@ -127,7 +127,7 @@ workflows:
             - test-backend
             - test-frontend
 
-      - test-codecov-orb-macos:
+      - test-codecov-orb:
           parameters:
             os: macos
             using_windows: true
@@ -135,7 +135,7 @@ workflows:
             - test-backend
             - test-frontend
 
-      - test-codecov-orb-windows:
+      - test-codecov-orb:
           parameters:
             os: windows
             using_windows: true
@@ -154,6 +154,4 @@ workflows:
           publish-version-tag: false
           publish-token-variable: ORB_PUBLISH_TOKEN
           requires:
-            - test-codecov-orb-linux
-            - test-codecov-orb-macos
-            - test-codecov-orb-windows
+            - test-codecov-orb

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,6 +50,10 @@ jobs:
       - python/install-packages:
           pkg-manager: pip
       - run: python3 -m pytest --junitxml=junit/test-results.xml --cov=src --cov-report=xml --cov-report=html test/unit
+      - persist_to_workspace:
+          root: .
+          paths:
+            - coverage.xml
   test-frontend:
     executor: node
     steps:
@@ -57,6 +61,10 @@ jobs:
       - node/install-npm
       - run: npm install
       - run: npm test
+      - persist_to_workspace:
+          root: .
+          paths:
+            - coverage/coverage-final.json
   test-codecov-orb:
     parameters:
       os:
@@ -64,6 +72,8 @@ jobs:
     executor: << parameters.os >>
     steps:
       - checkout
+      - attach_workspace:
+          at: .
       - codecov/upload:
           flags: backend
       - codecov/upload:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -75,7 +75,7 @@ jobs:
       - attach_workspace:
           at: .
       - when:
-          condition: << parameters.os >> == 'windows'
+          condition: << parameters.os >> == windows
           steps:
             - codecov/upload:
                 flags: backend
@@ -86,7 +86,7 @@ jobs:
                 using_windows: true
                 xtra_args: -v -Z
       - unless:
-          condition: << parameters.os >> == 'windows'
+          condition: << parameters.os >> == windows
           steps:
             - codecov/upload:
                 flags: backend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.1
+**Fixes**
+- #87 Fix support for Windows executors
+
 ## 1.2.0
 **Features**
 - #84 Allow extra parameters to be specified from the bash uploader

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # codecov-circleci-orb
 
-## Latest version 1.1.6
+## Latest version 1.2.1
 
 [![codecov.io](https://codecov.io/github/codecov/codecov-circleci-orb/coverage.svg?branch=master)](https://codecov.io/github/codecov/codecov-circleci-orb)
 [![Circle CI](https://circleci.com/gh/codecov/codecov-circleci-orb.png?style=badge)](https://circleci.com/gh/codecov/codecov-circleci-orb)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-circleci-orb",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-circleci-orb",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Codecov CircleCI Orb",
   "main": "index.js",
   "devDependencies": {

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -76,7 +76,7 @@ commands:
                       name: Upload Coverage Results
                       command: |
                         $arguments=@(
-                          '-Q "codecov-circleci-orb-1.2.1"',
+                          '-Q "codecov-circleci-orb-1.2.1"'
                         )
                         If ( "<< parameters.file >>" -ne "") {$arguments += '-f << parameters.file >>'}
                         If ( "<< parameters.xtra_args >>" -ne "") {$arguments += '<< parameters.xtra_args >>'}

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -77,9 +77,6 @@ commands:
                       command: |
                         $arguments=@(
                           '-Q "codecov-circleci-orb-1.2.1"',
-                          '-t "<< parameters.token >>"',
-                          '-n "<< parameters.upload_name >>"',
-                          '-F "<< parameters.flags >>"'
                         )
                         If ( "<< parameters.file >>" -ne "") {$arguments += '-f << parameters.file >>'}
                         If ( "<< parameters.xtra_args >>" -ne "") {$arguments += '<< parameters.xtra_args >>'}

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -88,9 +88,9 @@ commands:
                           $arguments += "-f"
                           $arguments += "<< parameters.file >>"
                         }
-                        If ( "<< parameters.name >>" -ne "") {
+                        If ( "<< parameters.upload_name >>" -ne "") {
                           $arguments += "-n"
-                          $arguments += "<< parameters.name >>"
+                          $arguments += "<< parameters.upload_name >>"
                         }
                         If ( "<< parameters.xtra_args >>" -ne "") {
                           foreach ($arg in "<< parameters.xtra_args >>".split( " " ) ) {

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -42,8 +42,7 @@ commands:
         type: string
         default: "always"
       xtra_args:
-        description: Any extra flags as provided by the bash uploader (e.g. `-v -Z`). Windows builds must provide extra flags as
-          query string (e.g. `-i=src/&-v=$true&-Z=$true` for `-i src/ -v -Z`)
+        description: Any extra flags as provided by the bash uploader (e.g. `-v -Z`).
         type: string
         default: ""
     steps:
@@ -76,11 +75,14 @@ commands:
                   - run:
                       name: Upload Coverage Results
                       command: |
-                        $arguments=@{}
-                        If ( "<< parameters.file >>" -ne "") {$arguments['-f'] = "<< parameters.file >>" }
+                        $arguments=@[]
+                        If ( "<< parameters.file >>" -ne "") {
+                          $arguments += "-f"
+                          $arguments += "<< parameters.file >>"
+                        }
                         If ( "<< parameters.xtra_args >>" -ne "") {
-                          foreach ($pair in "<< parameters.xtra_args >>".split("&")) {
-                            $arguments[$pair.split("=")[0]] = "${pair.split('=')[1]}"
+                          foreach ($arg in "<< parameters.xtra_args >>".split( " " ) ) {
+                            $arguments += $arg
                           }
                         }
                         chmod +x codecov

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -77,7 +77,7 @@ commands:
                       command: |
                         $arguments=@()
                         If ( "<< parameters.file >>" -ne "") {$arguments += '-f << parameters.file >>'}
-                        chmod +x .codecov
+                        chmod +x codecov
                         codecov \
                           -Q "codecov-circleci-orb-1.2.1" \
                           -t "<< parameters.token >>" \

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -75,9 +75,7 @@ commands:
                   - run:
                       name: Upload Coverage Results
                       command: |
-                        $arguments=@(
-                          '-Q "codecov-circleci-orb-1.2.1"'
-                        )
+                        $arguments=@()
                         If ( "<< parameters.file >>" -ne "") {$arguments += '-f << parameters.file >>'}
                         If ( "<< parameters.xtra_args >>" -ne "") {$arguments += '<< parameters.xtra_args >>'}
                         chmod +x codecov

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -75,7 +75,12 @@ commands:
                   - run:
                       name: Upload Coverage Results
                       command: |
-                        $arguments = @()
+                        $arguments = @(
+                          "-Q", "codecov-circleci-orb-1.2.1",
+                          "-t", "<< parameters.token >>",
+                          "-n", "<< parameters.upload_name >>",
+                          "-F", "<< parameters.flags >>"
+                        )
                         If ( "<< parameters.file >>" -ne "") {
                           $arguments += "-f"
                           $arguments += "<< parameters.file >>"
@@ -86,8 +91,6 @@ commands:
                           }
                         }
                         chmod +x codecov
-                        echo $arguments
-                        echo @arguments
                         bash ./codecov @arguments
       - unless:
           condition: << parameters.using_windows >>

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -84,6 +84,8 @@ commands:
                           }
                         }
                         chmod +x codecov
+                        echo $arguments
+                        echo @arguments
                         bash ./codecov @arguments
       - unless:
           condition: << parameters.using_windows >>

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -75,6 +75,7 @@ commands:
                   - run:
                       name: Upload Coverage Results
                       command: |
+                        bash ./codecov -f coverage/coverage-final.json -v -Z
                         $arguments=@()
                         If ( "<< parameters.file >>" -ne "") {$arguments += '-f << parameters.file >>'}
                         If ( "<< parameters.xtra_args >>" -ne "") {$arguments += '<< parameters.xtra_args >>'}

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -67,8 +67,8 @@ commands:
                           echo $i
                           echo "url"
                           echo "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM"
-                          echo (curl "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") -match "codecov"
-                          echo (curl "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") -match "codecov" -split " "
+                          echo ((curl "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") -match "codecov")
+                          echo ((curl "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") -match "codecov" -split " ")
                           $hash = ((curl "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") -match "codecov" -split " ")[0]
                           echo "hash"
                           echo $hash

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -78,7 +78,7 @@ commands:
                         $arguments=@()
                         If ( "<< parameters.file >>" -ne "") {$arguments += '-f << parameters.file >>'}
                         chmod +x codecov
-                        codecov \
+                        ./codecov \
                           -Q "codecov-circleci-orb-1.2.1" \
                           -t "<< parameters.token >>" \
                           -n "<< parameters.upload_name >>" \

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -68,14 +68,16 @@ commands:
                             echo "Published has: ${hash}"
                             echo "SHASUMs do not match, exiting."
                             exit 1
+                          } Else {
+                            echo "OK"
                           }
                         }
                   - run:
                       name: Upload Coverage Results
                       command: |
                         $arguments=@()
-                        If (<< parameters.file >> -ne "") {$arguments += '-f << parameters.file >>'}
-                        ./codecov \
+                        If ( "<< parameters.file >>" -ne "") {$arguments += '-f << parameters.file >>'}
+                        codecov \
                           -Q "codecov-circleci-orb-1.2.1" \
                           -t "<< parameters.token >>" \
                           -n "<< parameters.upload_name >>" \

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -83,7 +83,7 @@ commands:
                         )
                         If ( "<< parameters.file >>" -ne "") {$arguments += '-f << parameters.file >>'}
                         chmod +x codecov
-                        ./codecov "$arguments"
+                        bash codecov "$arguments"
       - unless:
           condition: << parameters.using_windows >>
           steps:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -75,10 +75,7 @@ commands:
                   - run:
                       name: Upload Coverage Results
                       command: |
-                        $arguments = @(
-                          "-Q", "codecov-circleci-orb-1.2.1",
-                          "-n", "<< parameters.upload_name >>"
-                        )
+                        $arguments = @( "-Q", "codecov-circleci-orb-1.2.1" )
                         If ( "<< parameters.token >>" -ne "") {
                           $arguments += "-t"
                           $arguments += "<< parameters.token >>"
@@ -90,6 +87,10 @@ commands:
                         If ( "<< parameters.file >>" -ne "") {
                           $arguments += "-f"
                           $arguments += "<< parameters.file >>"
+                        }
+                        If ( "<< parameters.name >>" -ne "") {
+                          $arguments += "-n"
+                          $arguments += "<< parameters.name >>"
                         }
                         If ( "<< parameters.xtra_args >>" -ne "") {
                           foreach ($arg in "<< parameters.xtra_args >>".split( " " ) ) {

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -75,7 +75,7 @@ commands:
                   - run:
                       name: Upload Coverage Results
                       command: |
-                        $arguments=@[]
+                        $arguments = @()
                         If ( "<< parameters.file >>" -ne "") {
                           $arguments += "-f"
                           $arguments += "<< parameters.file >>"

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -60,11 +60,13 @@ commands:
                       name: Validate Codecov Bash Uploader
                       command: |
                         VERSION=$(grep 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
-                        for i in 1 256 512
-                        do
-                          shasum -a $i -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM) ||
-                          shasum -a $i -c <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM | grep -w "codecov")
-                        done
+                        $algorithms = 1, 256, 512
+                        foreach ($algorithm in $algorithms) {
+                          $hash = curl -Uri "https://raw.githubusercontent.com/codecov/codecov-bash${VERSION}/SHA${algorithm}SUM"
+                          echo $hash
+                          echo (Get-FileHash codecov).hash
+                          (Get-FileHash codecov).hash -eq $hash
+                        }
                   - run:
                       name: Upload Coverage Results
                       command: |

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -51,7 +51,7 @@ commands:
           steps:
             - run:
                 name: Download Codecov Bash Uploader
-                command: curl -Outfile codecov.sh -Uri << parameters.url >>
+                command: curl -Outfile codecov -Uri << parameters.url >>
                 when: << parameters.when >>
             - when:
                 condition: << parameters.validate_url >>
@@ -83,11 +83,11 @@ commands:
                         )
                         If ( "<< parameters.file >>" -ne "") {$arguments += '-f << parameters.file >>'}
                         If ( "<< parameters.xtra_args >>" -ne "") {$arguments += '<< parameters.xtra_args >>'}
-                        chmod +x codecov.sh
+                        chmod +x codecov
                         echo "$arguments"
                         ls
                         pwd
-                        sh codecov.sh "$arguments"
+                        ./codecov @arguments
       - unless:
           condition: << parameters.using_windows >>
           steps:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -29,6 +29,10 @@ commands:
         description: Custom url to submit the codecov result. Default to "https://codecov.io/bash"
         type: string
         default: "https://codecov.io/bash"
+      using_windows:
+        description: Is this being run in a Windows setup?
+        type: boolean
+        default: false
       validate_url:
         description: Validate the url before submitting the codecov result. https://docs.codecov.io/docs/about-the-codecov-bash-uploader#validating-the-bash-script
         type: boolean
@@ -42,31 +46,65 @@ commands:
         type: string
         default: ""
     steps:
-      - run:
-          name: Download Codecov Bash Uploader
-          command: curl -fLso codecov << parameters.url >>
-          when: << parameters.when >>
       - when:
-          condition: << parameters.validate_url >>
+          condition: << parameters.using_windows >>
           steps:
             - run:
-                name: Validate Codecov Bash Uploader
-                command: |
-                  VERSION=$(grep 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
-                  for i in 1 256 512
-                  do
-                    shasum -a $i -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM) ||
-                    shasum -a $i -c <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM | grep -w "codecov")
-                  done
+                name: Download Codecov Bash Uploader
+                command: curl -Outfile codecov -Uri << parameters.url >>
+                when: << parameters.when >>
+            - when:
+                condition: << parameters.validate_url >>
+                steps:
+                  - run:
+                      name: Validate Codecov Bash Uploader
+                      command: |
+                        VERSION=$(grep 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
+                        for i in 1 256 512
+                        do
+                          shasum -a $i -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM) ||
+                          shasum -a $i -c <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM | grep -w "codecov")
+                        done
+                  - run:
+                      name: Upload Coverage Results
+                      command: |
+                        args=()
+                        [[ -n "<< parameters.file >>" ]] && args+=( '-f << parameters.file >>' )
+                        [[ -n "<< parameters.xtra_args >>" ]] && args+=( '<< parameters.xtra_args >>' )
+                        bash codecov \
+                          -Q "codecov-circleci-orb-1.2.0" \
+                          -t "<< parameters.token >>" \
+                          -n "<< parameters.upload_name >>" \
+                          -F "<< parameters.flags >>" \
+                          ${args[@]}
+      - unless:
+          condition: << parameters.using_windows >>
+          steps:
             - run:
-                name: Upload Coverage Results
-                command: |
-                  args=()
-                  [[ -n "<< parameters.file >>" ]] && args+=( '-f << parameters.file >>' )
-                  [[ -n "<< parameters.xtra_args >>" ]] && args+=( '<< parameters.xtra_args >>' )
-                  bash codecov \
-                    -Q "codecov-circleci-orb-1.2.0" \
-                    -t "<< parameters.token >>" \
-                    -n "<< parameters.upload_name >>" \
-                    -F "<< parameters.flags >>" \
-                    ${args[@]}
+                name: Download Codecov Bash Uploader
+                command: curl -fLso codecov << parameters.url >>
+                when: << parameters.when >>
+            - when:
+                condition: << parameters.validate_url >>
+                steps:
+                  - run:
+                      name: Validate Codecov Bash Uploader
+                      command: |
+                        VERSION=$(grep 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
+                        for i in 1 256 512
+                        do
+                          shasum -a $i -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM) ||
+                          shasum -a $i -c <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM | grep -w "codecov")
+                        done
+                  - run:
+                      name: Upload Coverage Results
+                      command: |
+                        args=()
+                        [[ -n "<< parameters.file >>" ]] && args+=( '-f << parameters.file >>' )
+                        [[ -n "<< parameters.xtra_args >>" ]] && args+=( '<< parameters.xtra_args >>' )
+                        bash codecov \
+                          -Q "codecov-circleci-orb-1.2.0" \
+                          -t "<< parameters.token >>" \
+                          -n "<< parameters.upload_name >>" \
+                          -F "<< parameters.flags >>" \
+                          ${args[@]}

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -82,7 +82,7 @@ commands:
                           '-F "<< parameters.flags >>"'
                         )
                         If ( "<< parameters.file >>" -ne "") {$arguments += '-f << parameters.file >>'}
-                        If ( "<< parameters.xtra_args >>" -ne "") {$arguments += '<< parameters.xtra_args'}
+                        If ( "<< parameters.xtra_args >>" -ne "") {$arguments += '<< parameters.xtra_args >>'}
                         chmod +x codecov
                         echo "$arguments"
                         ls

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -60,8 +60,18 @@ commands:
                       name: Validate Codecov Bash Uploader
                       command: |
                         $VERSION=((Select-String -path codecov 'VERSION=\"[0-9\.]*\"' | ForEach-Object {$_.Matches} | Foreach-Object {$_.Groups[0].Value})-split '"')[1]
+                        echo "version"
+                        echo $VERSION
                         foreach ($i in 1, 256, 512) {
+                          echo "i"
+                          echo $i
+                          echo "url"
+                          echo "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM"
+                          echo (curl "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") -match "codecov"
+                          echo (curl "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") -match "codecov" -split " "
                           $hash = ((curl "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") -match "codecov" -split " ")[0]
+                          echo "hash"
+                          echo $hash
                           If ((Get-FileHash -Algorithm "SHA${i}" codecov).hash.ToLower() -ne $hash) {
                             echo "hash"
                             echo $hash

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -87,7 +87,7 @@ commands:
                         echo "$arguments"
                         ls
                         pwd
-                        ./codecov @arguments
+                        bash ./codecov @arguments
       - unless:
           condition: << parameters.using_windows >>
           steps:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -77,7 +77,7 @@ commands:
                       name: Upload Coverage Results
                       command: |
                         $arguments=@{}
-                        If ( "<< parameters.file >>" -ne "") {$arguments['-f'] = << parameters.file >>}
+                        If ( "<< parameters.file >>" -ne "") {$arguments['-f'] = "<< parameters.file >>" }
                         If ( "<< parameters.xtra_args >>" -ne "") {
                           foreach ($pair in << parameters.xtra_args >>.split("&")) {
                             $arguments[$pair.split("=")[0]] = $pair.split("=")[1]

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -77,7 +77,7 @@ commands:
                       command: |
                         $arguments = @(
                           "-Q", "codecov-circleci-orb-1.2.1",
-                          "-n", "<< parameters.upload_name >>",
+                          "-n", "<< parameters.upload_name >>"
                         )
                         If ( "<< parameters.token >>" -ne "") {
                           $arguments += "-t"

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -62,7 +62,11 @@ commands:
                         $VERSION=((Select-String -path codecov 'VERSION=\"[0-9\.]*\"' | ForEach-Object {$_.Matches} | Foreach-Object {$_.Groups[0].Value})-split '"')[1]
                         foreach ($i in 1, 256, 512) {
                           $hash = ((curl "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") -match "codecov" -split " ")[0]
-                          (Get-FileHash codecov).hash.ToLower() -eq $hash
+                          If ((Get-FileHash -Algorithm "SHA${i}" codecov).hash.ToLower() -ne $hash) {
+                            echo $hash
+                            echo (Get-FileHash -Algorithm "SHA${i}" codecov).hash.ToLower()
+                            exit 1
+                          }
                         }
                   - run:
                       name: Upload Coverage Results
@@ -74,7 +78,7 @@ commands:
                           -t "<< parameters.token >>" \
                           -n "<< parameters.upload_name >>" \
                           -F "<< parameters.flags >>" \
-                          @arguments
+                          "$arguments"
       - unless:
           condition: << parameters.using_windows >>
           steps:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -87,7 +87,7 @@ commands:
                         echo "$arguments"
                         ls
                         pwd
-                        bash codecov "$arguments"
+                        ./codecov "$arguments"
       - unless:
           condition: << parameters.using_windows >>
           steps:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -60,21 +60,11 @@ commands:
                       name: Validate Codecov Bash Uploader
                       command: |
                         $VERSION=((Select-String -path codecov 'VERSION=\"[0-9\.]*\"' | ForEach-Object {$_.Matches} | Foreach-Object {$_.Groups[0].Value})-split '"')[1]
-                        echo "version"
-                        echo $VERSION
                         foreach ($i in 1, 256, 512) {
-                          echo "i"
-                          echo $i
-                          echo "url"
-                          echo "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM"
-                          echo ((curl "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") -match "codecov")
-                          echo ((curl "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") -match "codecov" -split " ")
-                          $hash = ((curl "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") -match "codecov" -split " ")[0]
+                          $hash = (((curl "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM")[0])-split( " " ))[0]
                           echo "hash"
                           echo $hash
                           If ((Get-FileHash -Algorithm "SHA${i}" codecov).hash.ToLower() -ne $hash) {
-                            echo "hash"
-                            echo $hash
                             echo "file hash"
                             echo (Get-FileHash -Algorithm "SHA${i}" codecov).hash.ToLower()
                             exit 1

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -77,10 +77,16 @@ commands:
                       command: |
                         $arguments = @(
                           "-Q", "codecov-circleci-orb-1.2.1",
-                          "-t", "<< parameters.token >>",
                           "-n", "<< parameters.upload_name >>",
-                          "-F", "<< parameters.flags >>"
                         )
+                        If ( "<< parameters.token >>" -ne "") {
+                          $arguments += "-t"
+                          $arguments += "<< parameters.token >>"
+                        }
+                        If ( "<< parameters.flags >>" -ne "") {
+                          $arguments += "-F"
+                          $arguments += "<< parameters.flags >>"
+                        }
                         If ( "<< parameters.file >>" -ne "") {
                           $arguments += "-f"
                           $arguments += "<< parameters.file >>"

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -62,11 +62,11 @@ commands:
                         $VERSION=((Select-String -path codecov 'VERSION=\"[0-9\.]*\"' | ForEach-Object {$_.Matches} | Foreach-Object {$_.Groups[0].Value})-split '"')[1]
                         foreach ($i in 1, 256, 512) {
                           $hash = (((curl "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM")[0])-split( " " ))[0]
-                          echo "hash"
-                          echo $hash
-                          If ((Get-FileHash -Algorithm "SHA${i}" codecov).hash.ToLower() -ne $hash) {
-                            echo "file hash"
-                            echo (Get-FileHash -Algorithm "SHA${i}" codecov).hash.ToLower()
+                          $scripthash = (Get-FileHash -Algorithm "SHA${i}" codecov).hash.ToLower()
+                          If ($scripthash -ne $hash) {
+                            echo "Script hash: ${scripthash}"
+                            echo "Published has: ${hash}"
+                            echo "SHASUMs do not match, exiting."
                             exit 1
                           }
                         }
@@ -75,7 +75,7 @@ commands:
                       command: |
                         $arguments=@()
                         If (<< parameters.file >> -ne "") {$arguments += '-f << parameters.file >>'}
-                        bash codecov \
+                        ./codecov \
                           -Q "codecov-circleci-orb-1.2.1" \
                           -t "<< parameters.token >>" \
                           -n "<< parameters.upload_name >>" \

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -76,6 +76,10 @@ commands:
                       name: Upload Coverage Results
                       command: |
                         bash ./codecov -f coverage/coverage-final.json -v -Z
+                        echo "next attempt"
+                        bash ./codecov "-f coverage/coverage-final.json -v -Z"
+                        echo "next attempt"
+                        bash ./codecov "-f coverage/coverage-final.json" "-v -Z"
                         $arguments=@()
                         If ( "<< parameters.file >>" -ne "") {$arguments += '-f << parameters.file >>'}
                         If ( "<< parameters.xtra_args >>" -ne "") {$arguments += '<< parameters.xtra_args >>'}

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -79,8 +79,8 @@ commands:
                         $arguments=@{}
                         If ( "<< parameters.file >>" -ne "") {$arguments['-f'] = "<< parameters.file >>" }
                         If ( "<< parameters.xtra_args >>" -ne "") {
-                          foreach ($pair in << parameters.xtra_args >>.split("&")) {
-                            $arguments[$pair.split("=")[0]] = $pair.split("=")[1]
+                          foreach ($pair in "<< parameters.xtra_args >>".split("&")) {
+                            $arguments[$pair.split("=")[0]] = "${pair.split('=')[1]}"
                           }
                         }
                         chmod +x codecov

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -75,15 +75,15 @@ commands:
                   - run:
                       name: Upload Coverage Results
                       command: |
-                        $arguments=@()
+                        $arguments=@(
+                          '-Q "codecov-circleci-orb-1.2.1"',
+                          '-t "<< parameters.token >>"',
+                          '-n "<< parameters.upload_name >>"',
+                          '-F "<< parameters.flags >>"'
+                        )
                         If ( "<< parameters.file >>" -ne "") {$arguments += '-f << parameters.file >>'}
                         chmod +x codecov
-                        ./codecov \
-                          -Q "codecov-circleci-orb-1.2.1" \
-                          -t "<< parameters.token >>" \
-                          -n "<< parameters.upload_name >>" \
-                          -F "<< parameters.flags >>" \
-                          "$arguments"
+                        ./codecov "$arguments"
       - unless:
           condition: << parameters.using_windows >>
           steps:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -67,15 +67,14 @@ commands:
                   - run:
                       name: Upload Coverage Results
                       command: |
-                        args=()
-                        [[ -n "<< parameters.file >>" ]] && args+=( '-f << parameters.file >>' )
-                        [[ -n "<< parameters.xtra_args >>" ]] && args+=( '<< parameters.xtra_args >>' )
+                        $arguments=@()
+                        If (<< parameters.file >> -ne "") {$arguments += '-f << parameters.file >>'}
                         bash codecov \
-                          -Q "codecov-circleci-orb-1.2.0" \
+                          -Q "codecov-circleci-orb-1.2.1" \
                           -t "<< parameters.token >>" \
                           -n "<< parameters.upload_name >>" \
                           -F "<< parameters.flags >>" \
-                          ${args[@]}
+                          @arguments
       - unless:
           condition: << parameters.using_windows >>
           steps:
@@ -102,7 +101,7 @@ commands:
                         [[ -n "<< parameters.file >>" ]] && args+=( '-f << parameters.file >>' )
                         [[ -n "<< parameters.xtra_args >>" ]] && args+=( '<< parameters.xtra_args >>' )
                         bash codecov \
-                          -Q "codecov-circleci-orb-1.2.0" \
+                          -Q "codecov-circleci-orb-1.2.1" \
                           -t "<< parameters.token >>" \
                           -n "<< parameters.upload_name >>" \
                           -F "<< parameters.flags >>" \

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -87,7 +87,7 @@ commands:
                         echo "$arguments"
                         ls
                         pwd
-                        codecov.sh "$arguments"
+                        ./codecov.sh "$arguments"
       - unless:
           condition: << parameters.using_windows >>
           steps:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -87,7 +87,7 @@ commands:
                         echo "$arguments"
                         ls
                         pwd
-                        ./codecov.sh "$arguments"
+                        sh codecov.sh "$arguments"
       - unless:
           condition: << parameters.using_windows >>
           steps:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -51,7 +51,7 @@ commands:
           steps:
             - run:
                 name: Download Codecov Bash Uploader
-                command: curl -Outfile codecov -Uri << parameters.url >>
+                command: curl -Outfile codecov.sh -Uri << parameters.url >>
                 when: << parameters.when >>
             - when:
                 condition: << parameters.validate_url >>
@@ -83,11 +83,11 @@ commands:
                         )
                         If ( "<< parameters.file >>" -ne "") {$arguments += '-f << parameters.file >>'}
                         If ( "<< parameters.xtra_args >>" -ne "") {$arguments += '<< parameters.xtra_args >>'}
-                        chmod +x codecov
+                        chmod +x codecov.sh
                         echo "$arguments"
                         ls
                         pwd
-                        ./codecov "$arguments"
+                        codecov.sh "$arguments"
       - unless:
           condition: << parameters.using_windows >>
           steps:

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -73,6 +73,11 @@ commands:
                           }
                         }
                   - run:
+                      name: List files
+                      command: |
+                        ls
+                        pwd
+                  - run:
                       name: Upload Coverage Results
                       command: |
                         $arguments=@()

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -42,7 +42,8 @@ commands:
         type: string
         default: "always"
       xtra_args:
-        description: Any extra flags as provided by the bash uploader (e.g. `-v -Z`)
+        description: Any extra flags as provided by the bash uploader (e.g. `-v -Z`). Windows builds must provide extra flags as
+          query string (e.g. `-i=src/&-v=$true&-Z=$true` for `-i src/ -v -Z`)
         type: string
         default: ""
     steps:
@@ -75,18 +76,14 @@ commands:
                   - run:
                       name: Upload Coverage Results
                       command: |
-                        bash ./codecov -f coverage/coverage-final.json -v -Z
-                        echo "next attempt"
-                        bash ./codecov "-f coverage/coverage-final.json -v -Z"
-                        echo "next attempt"
-                        bash ./codecov "-f coverage/coverage-final.json" "-v -Z"
-                        $arguments=@()
-                        If ( "<< parameters.file >>" -ne "") {$arguments += '-f << parameters.file >>'}
-                        If ( "<< parameters.xtra_args >>" -ne "") {$arguments += '<< parameters.xtra_args >>'}
+                        $arguments=@{}
+                        If ( "<< parameters.file >>" -ne "") {$arguments['-f'] = << parameters.file >>
+                        If ( "<< parameters.xtra_args >>" -ne "") {
+                          foreach ($pair in << parameters.xtra_args >>.split("&")) {
+                            $arguments[$pair.split("=")[0]] = $pair.split("=")[1]
+                          }
+                        }
                         chmod +x codecov
-                        echo "$arguments"
-                        ls
-                        pwd
                         bash ./codecov @arguments
       - unless:
           condition: << parameters.using_windows >>

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -83,6 +83,9 @@ commands:
                         )
                         If ( "<< parameters.file >>" -ne "") {$arguments += '-f << parameters.file >>'}
                         chmod +x codecov
+                        echo "$arguments"
+                        ls
+                        pwd
                         bash codecov "$arguments"
       - unless:
           condition: << parameters.using_windows >>

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -59,13 +59,10 @@ commands:
                   - run:
                       name: Validate Codecov Bash Uploader
                       command: |
-                        VERSION=$(grep 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
-                        $algorithms = 1, 256, 512
-                        foreach ($algorithm in $algorithms) {
-                          $hash = curl -Uri "https://raw.githubusercontent.com/codecov/codecov-bash${VERSION}/SHA${algorithm}SUM"
-                          echo $hash
-                          echo (Get-FileHash codecov).hash
-                          (Get-FileHash codecov).hash -eq $hash
+                        $VERSION=((Select-String -path codecov 'VERSION=\"[0-9\.]*\"' | ForEach-Object {$_.Matches} | Foreach-Object {$_.Groups[0].Value})-split '"')[1]
+                        foreach ($i in 1, 256, 512) {
+                          $hash = ((curl "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") -match "codecov" -split " ")[0]
+                          (Get-FileHash codecov).hash.ToLower() -eq $hash
                         }
                   - run:
                       name: Upload Coverage Results

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -82,6 +82,7 @@ commands:
                           '-F "<< parameters.flags >>"'
                         )
                         If ( "<< parameters.file >>" -ne "") {$arguments += '-f << parameters.file >>'}
+                        If ( "<< parameters.xtra_args >>" -ne "") {$arguments += '<< parameters.xtra_args'}
                         chmod +x codecov
                         echo "$arguments"
                         ls

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -73,15 +73,11 @@ commands:
                           }
                         }
                   - run:
-                      name: List files
-                      command: |
-                        ls
-                        pwd
-                  - run:
                       name: Upload Coverage Results
                       command: |
                         $arguments=@()
                         If ( "<< parameters.file >>" -ne "") {$arguments += '-f << parameters.file >>'}
+                        chmod +x .codecov
                         codecov \
                           -Q "codecov-circleci-orb-1.2.1" \
                           -t "<< parameters.token >>" \

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -77,7 +77,7 @@ commands:
                       name: Upload Coverage Results
                       command: |
                         $arguments=@{}
-                        If ( "<< parameters.file >>" -ne "") {$arguments['-f'] = << parameters.file >>
+                        If ( "<< parameters.file >>" -ne "") {$arguments['-f'] = << parameters.file >>}
                         If ( "<< parameters.xtra_args >>" -ne "") {
                           foreach ($pair in << parameters.xtra_args >>.split("&")) {
                             $arguments[$pair.split("=")[0]] = $pair.split("=")[1]

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -63,7 +63,9 @@ commands:
                         foreach ($i in 1, 256, 512) {
                           $hash = ((curl "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM") -match "codecov" -split " ")[0]
                           If ((Get-FileHash -Algorithm "SHA${i}" codecov).hash.ToLower() -ne $hash) {
+                            echo "hash"
                             echo $hash
+                            echo "file hash"
                             echo (Get-FileHash -Algorithm "SHA${i}" codecov).hash.ToLower()
                             exit 1
                           }


### PR DESCRIPTION
This PR adds support for Windows builds. It introduces the `using_windows` flag that must be set to `true` in order to properly validate the bash script with Powershell commands.

Fixes https://github.com/codecov/codecov-circleci-orb/issues/83