### PR TITLE
[semver:patch] Fix issue with Windows curling the bash script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.2.2
+**Fixes**
+- #88 Fixes issue with Windows curling the bash script
+
 ## 1.2.1
 **Fixes**
 - #87 Fix support for Windows executors

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # codecov-circleci-orb
 
-## Latest version 1.2.1
+## Latest version 1.2.2
 
 [![codecov.io](https://codecov.io/github/codecov/codecov-circleci-orb/coverage.svg?branch=master)](https://codecov.io/github/codecov/codecov-circleci-orb)
 [![Circle CI](https://circleci.com/gh/codecov/codecov-circleci-orb.png?style=badge)](https://circleci.com/gh/codecov/codecov-circleci-orb)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-circleci-orb",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Codecov CircleCI Orb",
   "main": "index.js",
   "devDependencies": {

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -51,7 +51,7 @@ commands:
           steps:
             - run:
                 name: Download Codecov Bash Uploader
-                command: curl -Uri "<< parameters.url >>" > codecov
+                command: Invoke-WebRequest -Uri "<< parameters.url >>" -Outfile codecov
                 when: << parameters.when >>
             - when:
                 condition: << parameters.validate_url >>
@@ -61,11 +61,11 @@ commands:
                       command: |
                         $VERSION=((Select-String -path codecov 'VERSION=\"[0-9\.]*\"' | ForEach-Object {$_.Matches} | Foreach-Object {$_.Groups[0].Value})-split '"')[1]
                         foreach ($i in 1, 256, 512) {
-                          echo "https://github.com/codecov/codecov-bash/releases/download/${VERSION}/SHA${i}SUM"
-                          $hash = (((curl -Uri "https://github.com/codecov/codecov-bash/releases/download/${VERSION}/SHA${i}SUM")[0])-split( " " ))[0]
+                          echo "Pulling public hashes from https://github.com/codecov/codecov-bash/releases/download/${VERSION}/SHA${i}SUM"
+                          $hash = (((Invoke-WebRequest -Uri "https://github.com/codecov/codecov-bash/releases/download/${VERSION}/SHA${i}SUM")[0])-split( " " ))[0]
                           $scripthash = (Get-FileHash -Algorithm "SHA${i}" codecov).hash.ToLower()
                           If ($scripthash -ne $hash) {
-                            echo "Script hash: ${scripthash}"
+                            echo "Script hash:   ${scripthash}"
                             echo "Published has: ${hash}"
                             echo "SHASUMs do not match, exiting."
                             exit 1

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -51,7 +51,7 @@ commands:
           steps:
             - run:
                 name: Download Codecov Bash Uploader
-                command: curl -Outfile codecov -Uri << parameters.url >>
+                command: curl -Uri "<< parameters.url >>" > codecov
                 when: << parameters.when >>
             - when:
                 condition: << parameters.validate_url >>
@@ -61,7 +61,8 @@ commands:
                       command: |
                         $VERSION=((Select-String -path codecov 'VERSION=\"[0-9\.]*\"' | ForEach-Object {$_.Matches} | Foreach-Object {$_.Groups[0].Value})-split '"')[1]
                         foreach ($i in 1, 256, 512) {
-                          $hash = (((curl "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM")[0])-split( " " ))[0]
+                          echo "https://github.com/codecov/codecov-bash/releases/download/${VERSION}/SHA${i}SUM"
+                          $hash = (((curl -Uri "https://github.com/codecov/codecov-bash/releases/download/${VERSION}/SHA${i}SUM")[0])-split( " " ))[0]
                           $scripthash = (Get-FileHash -Algorithm "SHA${i}" codecov).hash.ToLower()
                           If ($scripthash -ne $hash) {
                             echo "Script hash: ${scripthash}"
@@ -75,7 +76,7 @@ commands:
                   - run:
                       name: Upload Coverage Results
                       command: |
-                        $arguments = @( "-Q", "codecov-circleci-orb-1.2.1" )
+                        $arguments = @( "-Q", "codecov-circleci-orb-1.2.2" )
                         If ( "<< parameters.token >>" -ne "") {
                           $arguments += "-t"
                           $arguments += "<< parameters.token >>"
@@ -125,7 +126,7 @@ commands:
                         [[ -n "<< parameters.file >>" ]] && args+=( '-f << parameters.file >>' )
                         [[ -n "<< parameters.xtra_args >>" ]] && args+=( '<< parameters.xtra_args >>' )
                         bash codecov \
-                          -Q "codecov-circleci-orb-1.2.1" \
+                          -Q "codecov-circleci-orb-1.2.2" \
                           -t "<< parameters.token >>" \
                           -n "<< parameters.upload_name >>" \
                           -F "<< parameters.flags >>" \


### PR DESCRIPTION
Using the given params expects a password for user `tfile`. This should not be necessary.