### PR TITLE
[semver:patch] Include sha{x}sum commands for windows bash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,12 +65,10 @@ jobs:
           root: .
           paths:
             - coverage/coverage-final.json
-  test-codecov-orb:
+  test-codecov-orb-non-windows:
     parameters:
       os:
         type: executor
-      using_windows:
-        type: boolean
     executor: << parameters.os >>
     steps:
       - checkout
@@ -78,13 +76,24 @@ jobs:
           at: .
       - codecov/upload:
           flags: backend
-          using_windows: << parameters.using_windows >>
       - codecov/upload:
           file: coverage/coverage-final.json
           flags: frontend
-          using_windows: << parameters.using_windows >>
           xtra_args: -v -Z
-
+  test-codecov-orb-windows:
+    executor:
+      name: win/default
+      shell: bash.exe
+    steps:
+      - checkout
+      - attach_workspace:
+          at: .
+      - codecov/upload:
+          flags: backend
+      - codecov/upload:
+          file: coverage/coverage-final.json
+          flags: frontend
+          xtra_args: -v -Z
 
 workflows:
   test-pack:
@@ -120,21 +129,15 @@ workflows:
     jobs:
       - test-backend
       - test-frontend
-      - test-codecov-orb:
+      - test-codecov-orb-non-windows:
           matrix:
-            alias: test-codecov-orb-non-windows
             parameters:
               os: [linux, macos]
-              using_windows: [false]
           requires:
             - test-backend
             - test-frontend
-      - test-codecov-orb:
-          matrix:
-            alias: test-codecov-orb-windows
-            parameters:
-              os: [windows]
-              using_windows: [true]
+
+      - test-codecov-orb-windows:
           requires:
             - test-backend
             - test-frontend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 1.2.3
+**Backwards Incompatibility**
+`using_windows` has been deprecated
+
+**Fixes**
+- #89 Fixes issue with running bash on Windows machines
+
 ## 1.2.2
 **Fixes**
 - #88 Fixes issue with Windows curling the bash script

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # codecov-circleci-orb
 
-## Latest version 1.2.2
+## Latest version 1.2.3
 
 [![codecov.io](https://codecov.io/github/codecov/codecov-circleci-orb/coverage.svg?branch=master)](https://codecov.io/github/codecov/codecov-circleci-orb)
 [![Circle CI](https://circleci.com/gh/codecov/codecov-circleci-orb.png?style=badge)](https://circleci.com/gh/codecov/codecov-circleci-orb)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-circleci-orb",
-  "version": "1.2.1",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-circleci-orb",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Codecov CircleCI Orb",
   "main": "index.js",
   "devDependencies": {

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -29,10 +29,6 @@ commands:
         description: Custom url to submit the codecov result. Default to "https://codecov.io/bash"
         type: string
         default: "https://codecov.io/bash"
-      using_windows:
-        description: Is this being run in a Windows setup?
-        type: boolean
-        default: false
       validate_url:
         description: Validate the url before submitting the codecov result. https://docs.codecov.io/docs/about-the-codecov-bash-uploader#validating-the-bash-script
         type: boolean
@@ -46,88 +42,40 @@ commands:
         type: string
         default: ""
     steps:
+      - run:
+          name: Download Codecov Bash Uploader
+          command: curl -fLso codecov << parameters.url >>
+          when: << parameters.when >>
       - when:
-          condition: << parameters.using_windows >>
+          condition: << parameters.validate_url >>
           steps:
             - run:
-                name: Download Codecov Bash Uploader
-                command: Invoke-WebRequest -Uri "<< parameters.url >>" -Outfile codecov
-                when: << parameters.when >>
-            - when:
-                condition: << parameters.validate_url >>
-                steps:
-                  - run:
-                      name: Validate Codecov Bash Uploader
-                      command: |
-                        $VERSION=((Select-String -path codecov 'VERSION=\"[0-9\.]*\"' | ForEach-Object {$_.Matches} | Foreach-Object {$_.Groups[0].Value})-split '"')[1]
-                        foreach ($i in 1, 256, 512) {
-                          echo "Pulling public hashes from https://github.com/codecov/codecov-bash/releases/download/${VERSION}/SHA${i}SUM"
-                          $hash = (((Invoke-WebRequest -Uri "https://github.com/codecov/codecov-bash/releases/download/${VERSION}/SHA${i}SUM")[0])-split( " " ))[0]
-                          $scripthash = (Get-FileHash -Algorithm "SHA${i}" codecov).hash.ToLower()
-                          If ($scripthash -ne $hash) {
-                            echo "Script hash:   ${scripthash}"
-                            echo "Published has: ${hash}"
-                            echo "SHASUMs do not match, exiting."
-                            exit 1
-                          } Else {
-                            echo "OK"
-                          }
-                        }
-                  - run:
-                      name: Upload Coverage Results
-                      command: |
-                        $arguments = @( "-Q", "codecov-circleci-orb-1.2.2" )
-                        If ( "<< parameters.token >>" -ne "") {
-                          $arguments += "-t"
-                          $arguments += "<< parameters.token >>"
-                        }
-                        If ( "<< parameters.flags >>" -ne "") {
-                          $arguments += "-F"
-                          $arguments += "<< parameters.flags >>"
-                        }
-                        If ( "<< parameters.file >>" -ne "") {
-                          $arguments += "-f"
-                          $arguments += "<< parameters.file >>"
-                        }
-                        If ( "<< parameters.upload_name >>" -ne "") {
-                          $arguments += "-n"
-                          $arguments += "<< parameters.upload_name >>"
-                        }
-                        If ( "<< parameters.xtra_args >>" -ne "") {
-                          foreach ($arg in "<< parameters.xtra_args >>".split( " " ) ) {
-                            $arguments += $arg
-                          }
-                        }
-                        chmod +x codecov
-                        bash ./codecov @arguments
-      - unless:
-          condition: << parameters.using_windows >>
-          steps:
+                name: Validate Codecov Bash Uploader
+                command: |
+                  VERSION=$(grep 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
+                  sha1sum -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA1SUM) ||
+                  sha1sum -c <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA1SUM | grep -w "codecov") ||
+                  shasum -a 1 -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA1SUM) ||
+                  shasum -a 1 -c <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA1SUM | grep -w "codecov")
+
+                  sha256sum -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA256SUM) ||
+                  sha256sum -c <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA256SUM | grep -w "codecov") ||
+                  shasum -a 256 -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA256SUM) ||
+                  shasum -a 256 -c <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA256SUM | grep -w "codecov")
+
+                  sha512sum -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA512SUM) ||
+                  sha512sum -c <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA512SUM | grep -w "codecov") ||
+                  shasum -a 512 -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA512SUM) ||
+                  shasum -a 512 -c <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA512SUM | grep -w "codecov")
             - run:
-                name: Download Codecov Bash Uploader
-                command: curl -fLso codecov << parameters.url >>
-                when: << parameters.when >>
-            - when:
-                condition: << parameters.validate_url >>
-                steps:
-                  - run:
-                      name: Validate Codecov Bash Uploader
-                      command: |
-                        VERSION=$(grep 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
-                        for i in 1 256 512
-                        do
-                          shasum -a $i -c --ignore-missing <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM) ||
-                          shasum -a $i -c <(curl -s https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA${i}SUM | grep -w "codecov")
-                        done
-                  - run:
-                      name: Upload Coverage Results
-                      command: |
-                        args=()
-                        [[ -n "<< parameters.file >>" ]] && args+=( '-f << parameters.file >>' )
-                        [[ -n "<< parameters.xtra_args >>" ]] && args+=( '<< parameters.xtra_args >>' )
-                        bash codecov \
-                          -Q "codecov-circleci-orb-1.2.2" \
-                          -t "<< parameters.token >>" \
-                          -n "<< parameters.upload_name >>" \
-                          -F "<< parameters.flags >>" \
-                          ${args[@]}
+                name: Upload Coverage Results
+                command: |
+                  args=()
+                  [[ -n "<< parameters.file >>" ]] && args+=( '-f << parameters.file >>' )
+                  [[ -n "<< parameters.xtra_args >>" ]] && args+=( '<< parameters.xtra_args >>' )
+                  bash codecov \
+                    -Q "codecov-circleci-orb-1.2.3" \
+                    -t "<< parameters.token >>" \
+                    -n "<< parameters.upload_name >>" \
+                    -F "<< parameters.flags >>" \
+                    ${args[@]}


### PR DESCRIPTION
Uses the sha{x} commands as further backups to systems that do not have `shasum`, namely Windows `bash.exe`