### PR TITLE
fix: env_var_name parameter type for token [semver:patch]

### DIFF
--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -19,8 +19,8 @@ commands:
         default: ""
       token:
         description: Set the private repository token as the value of the variable CODECOV_TOKEN using CircleCI Environment Variables.
-        type: string
-        default: ${CODECOV_TOKEN}
+        type: env_var_name
+        default: CODECOV_TOKEN
       upload_name:
         description: Custom defined name of the upload. Visible in Codecov UI
         type: string
@@ -75,7 +75,7 @@ commands:
                   [[ -n "<< parameters.xtra_args >>" ]] && args+=( '<< parameters.xtra_args >>' )
                   bash codecov \
                     -Q "codecov-circleci-orb-1.2.3" \
-                    -t "<< parameters.token >>" \
+                    -t "${<< parameters.token >>}" \
                     -n "<< parameters.upload_name >>" \
                     -F "<< parameters.flags >>" \
                     ${args[@]}


### PR DESCRIPTION
Change the parameter type for the user's token from `string` to `env_var_name`. They are functionally similar but this is meant to make it clear to users to _not_ commit their API token. 

Changes the default value from `${CODECOV_TOKEN}` to just `CODECOV_TOKEN`. The `${}` portion has been migrated to the implementation.

Links:
* https://circleci.com/docs/2.0/orbs-best-practices/?section=configuration#secrets-should-never-be-directly-entered
* https://circleci.com/docs/2.0/reusing-config/#environment-variable-name