### PR TITLE
[semver:minor] Allow specifying version of Codecov uploader

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,10 @@ jobs:
           file: coverage/coverage-final.json
           flags: frontend,linux
           xtra_args: -v -Z
+      - codecov/upload:
+          file: coverage/coverage-final.json
+          flags: version,linux
+          version: v0.1.0_8880
   test-codecov-orb-macos:
     macos:
       xcode: 11.4
@@ -85,6 +89,10 @@ jobs:
           file: coverage/coverage-final.json
           flags: frontend,macos
           xtra_args: -v -Z
+      - codecov/upload:
+          file: coverage/coverage-final.json
+          flags: version,macos
+          version: v0.1.0_8880
   test-codecov-orb-windows:
     executor:
       name: win/default
@@ -99,6 +107,10 @@ jobs:
           file: coverage/coverage-final.json
           flags: frontend,windows
           xtra_args: -v -Z
+      - codecov/upload:
+          file: coverage/coverage-final.json
+          flags: version,windows
+          version: v0.1.0_8880
 
 workflows:
   test-pack:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 3.1.0
+**Features**
+- #108 feat: Allow specifying version of Codecov uploader
+
+## 3.0.0
+Version 3.0.0 was a result of an unexpected deployment, but mirrors 2.0.0
+
 ## 2.0.0
 Version 2.0.0 represents a move to the new Codecov uploader and away from the bash uploader
 Functionality should be roughly the same, but will follow the arguments laid out in the new uploader

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # codecov-circleci-orb
 
-## Latest version 2.0.0
+## Latest version 3.1.0
 
 [![codecov.io](https://codecov.io/github/codecov/codecov-circleci-orb/coverage.svg?branch=master)](https://codecov.io/github/codecov/codecov-circleci-orb)
 [![Circle CI](https://circleci.com/gh/codecov/codecov-circleci-orb.png?style=badge)](https://circleci.com/gh/codecov/codecov-circleci-orb)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "codecov-circleci-orb",
-  "version": "2.0.0",
+  "version": "3.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "2.0.0",
+      "version": "3.1.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "5.2.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-circleci-orb",
-  "version": "2.0.0",
+  "version": "3.1.0",
   "description": "Codecov CircleCI Orb",
   "main": "index.js",
   "devDependencies": {

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -25,12 +25,8 @@ commands:
         description: Custom defined name of the upload. Visible in Codecov UI
         type: string
         default: ${CIRCLE_BUILD_NUM}
-      url:
-        description: Custom url to submit the codecov result. Default to "https://codecov.io/bash"
-        type: string
-        default: "https://codecov.io/bash"
-      validate_url:
-        description: Validate the url before submitting the codecov result. https://docs.codecov.io/docs/about-the-codecov-bash-uploader#validating-the-bash-script
+      validate:
+        description: Validate the uploader before uploading the codecov result.
         type: boolean
         default: true
       when:
@@ -41,43 +37,49 @@ commands:
         description: Any extra flags as provided by the bash uploader (e.g. `-v -Z`).
         type: string
         default: ""
+      version:
+        description: Which version of the Codecov Uploader to use (defaults to 'latest')
+        type: string
+        default: "latest"
     steps:
       - run:
-          name: Download Codecov Bash Uploader
-          command: curl -fLso codecov << parameters.url >>
+          name: Download Codecov Uploader
+          command: |
+            family=$(uname -s | tr '[:upper:]' '[:lower:]')
+            os="windows"
+            [[ $family == "darwin" ]] && os="macos"
+            [[ $family == "linux" ]] && os="linux"
+            echo "Detected ${os}"
+            echo "export os=${os}" >> $BASH_ENV
+
+            filename="codecov"
+            [[ $os == "windows" ]] && filename+=".exe"
+            echo "export filename=${filename}" >> $BASH_ENV
+            [[ $os == "macos" ]] && brew install gpg
+            curl -Os "https://uploader.codecov.io/<< parameters.version >>/${os}/${filename}"
           when: << parameters.when >>
       - when:
-          condition: << parameters.validate_url >>
+          condition: << parameters.validate >>
           steps:
             - run:
-                name: Validate Codecov Bash Uploader
+                name: Validate Codecov Uploader
                 command: |
-                  family=$(uname -s | tr '[:upper:]' '[:lower:]')
-                  os="windows"
-                  [[ $family == "darwin" ]] && os="macos"
-                  [[ $family == "linux" ]] && os="linux"
-                  echo "Detected ${os}"
-
-                  filename="codecov"
-                  [[ $os == "windows" ]] && filename+=".exe"
-                  [[ $os == "macos" ]] && brew install gpg
-                  curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --import # One-time step
-                  curl -Os "https://uploader.codecov.io/latest/${os}/${filename}"
-                  curl -Os "https://uploader.codecov.io/latest/${os}/${filename}.SHA256SUM"
-                  curl -Os "https://uploader.codecov.io/latest/${os}/${filename}.SHA256SUM.sig"
+                  curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --import # One-time step
+                  curl -Os "https://uploader.codecov.io/<< parameters.version >>/${os}/${filename}.SHA256SUM"
+                  curl -Os "https://uploader.codecov.io/<< parameters.version >>/${os}/${filename}.SHA256SUM.sig"
                   gpg --verify $filename.SHA256SUM.sig $filename.SHA256SUM
-                  shasum -a 256 -c $filename.SHA256SUM ||
-                    sha256sum -c $filename.SHA256SUM
-                  chmod +x $filename
-            - run:
-                name: Upload Coverage Results
-                command: |
-                  args=()
-                  [[ -n "<< parameters.file >>" ]] && args+=( '-f << parameters.file >>' )
-                  [[ -n "<< parameters.xtra_args >>" ]] && args+=( '<< parameters.xtra_args >>' )
-                  ./codecov \
-                    -Q "codecov-circleci-orb-2.0.0" \
-                    -t "${<< parameters.token >>}" \
-                    -n "<< parameters.upload_name >>" \
-                    -F "<< parameters.flags >>" \
-                    ${args[@]}
+                  shasum -a 256 -c $filename.SHA256SUM || sha256sum -c $filename.SHA256SUM
+      - run:
+          name: Upload Coverage Results
+          command: |
+            chmod +x $filename
+            args=()
+            [[ -n "<< parameters.file >>" ]] && args+=( '-f << parameters.file >>' )
+            [[ -n "<< parameters.xtra_args >>" ]] && args+=( '<< parameters.xtra_args >>' )
+            curl -H "Accept: application/json" "https://uploader.codecov.io/${os}/<< parameters.version >>" | grep -o '\"version\":\"v[0-9\.\_]\+\"' | head -1
+            ./$filename \
+              -Q "codecov-circleci-orb-3.1.0" \
+              -t "${<< parameters.token >>}" \
+              -n "<< parameters.upload_name >>" \
+              -F "<< parameters.flags >>" \
+              ${args[@]}


### PR DESCRIPTION
This allows for specifying `version` as part of the orb. Users can upload using that version of the Codecov uploader. It defaults to `latest`.