### PR TITLE
Revert "Explicitly specify bash shell on run steps"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,6 +117,7 @@ jobs:
   test-codecov-orb-windows:
     executor:
       name: win/default
+      shell: bash.exe
     steps:
       - checkout
       - attach_workspace:

--- a/README.md
+++ b/README.md
@@ -3,4 +3,4 @@
 ## Latest version 3.2.2
 
 [![codecov.io](https://codecov.io/github/codecov/codecov-circleci-orb/coverage.svg?branch=master)](https://codecov.io/github/codecov/codecov-circleci-orb)
-[![Circle CI](https://circleci.com/gh/codecov/codecov-circleci-orb.png?style=badge)](https://circleci.com/gh/codecov/codecov-circleci-orb)
+[![Circle CI](https://circleci.com/gh/codecov/codecov-circleci-orb.png?style=badge)](https://circleci.com/gh/codecov/codecov-circleci-orb) 

--- a/src/@orb.yml
+++ b/src/@orb.yml
@@ -46,7 +46,6 @@ commands:
     steps:
       - run:
           name: Download Codecov Uploader
-          shell: bash
           command: |
             family=$(uname -s | tr '[:upper:]' '[:lower:]')
             os="windows"
@@ -69,7 +68,6 @@ commands:
           steps:
             - run:
                 name: Validate Codecov Uploader
-                shell: bash
                 command: |
                   source $BASH_ENV
                   curl https://keybase.io/codecovsecurity/pgp_keys.asc | gpg --no-default-keyring --keyring trustedkeys.gpg --import # One-time step
@@ -79,7 +77,6 @@ commands:
                   shasum -a 256 -c $filename.SHA256SUM || sha256sum -c $filename.SHA256SUM
       - run:
           name: Upload Coverage Results
-          shell: bash
           command: |
             unset NODE_OPTIONS  # See https://github.com/codecov/uploader/issues/475
             source $BASH_ENV


### PR DESCRIPTION
Reverts codecov/codecov-circleci-orb#125

This will break on `alpine` builds