### PR TITLE
release: bump to 3.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
+## 3.2.3
+**Fixes**
+- #105: Bump path-parse from 1.0.6 to 1.0.7
+- #126: Bump dependencies
+- #127: fix(ci): install Git
+- #130: Bump dependencies
+- #132: Disabling auto update on brew install
+- #135: ci: bump deps
+
 ## 3.2.2
-**Fixes
+**Fixes**
 - #120: fix: unset NODE_OPTIONS to prevent exit 4
 
 ## 3.2.0

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codecov-circleci-orb",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "codecov-circleci-orb",
-      "version": "3.2.2",
+      "version": "3.2.3",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-circleci-orb",
-  "version": "3.2.2",
+  "version": "3.2.3",
   "description": "Codecov CircleCI Orb",
   "main": "index.js",
   "devDependencies": {


### PR DESCRIPTION
## 3.2.3
**Fixes**
- #105: Bump path-parse from 1.0.6 to 1.0.7
- #126: Bump dependencies
- #127: fix(ci): install Git
- #130: Bump dependencies
- #132: Disabling auto update on brew install
- #135: ci: bump deps