### PR TITLE
fix: apply when parameters to all steps

### DIFF
--- a/src/commands/upload.yml
+++ b/src/commands/upload.yml
@@ -59,6 +59,7 @@ steps:
             command: <<include(scripts/validate.sh)>>
             environment:
               CODECOV_PUBLIC_PGP_KEY: <<include(scripts/pgp_keys.asc)>>
+            when: << parameters.when >>
   - run:
       name: Upload Coverage Results
       command: <<include(scripts/upload.sh)>>
@@ -68,3 +69,4 @@ steps:
         PARAM_TOKEN: << parameters.token >>
         PARAM_UPLOAD_NAME: << parameters.upload_name >>
         PARAM_XTRA_ARGS: << parameters.xtra_args >>
+      when: << parameters.when >>


### PR DESCRIPTION
Currently this orb doesn't upload coverage data when it's failed.

Let's say:

- We have two flags A and B
  - A flags is for files under `/a` directory
  - B flags is for files under `/b` directory
- We enable `carryforward` for both
- We use `parallelism: 2` for both
- We set `after_n_builds` to 4
- Test suite for A runs when files under `/a` is changed
- Test suite for B runs when files under `/b` is changed
- Both test suites have 1 % chance to failure because of flaky tests
- On the latest commit for main branch, there were changes for both `/a` and `/b` and CI for A was failed

In this case, all PRs which only touch `/b` won't receive coverage report since it only carryforward 1 of 2.

I believe this `when` parameter should be applied to all steps.