### PR TITLE
Fix CIRCLE_BUILD_NUM bug and allows users to specify env vars as flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,4 @@
 
 [![codecov.io](https://codecov.io/github/codecov/codecov-circleci-orb/coverage.svg?branch=master)](https://codecov.io/github/codecov/codecov-circleci-orb)
 [![Circle CI](https://circleci.com/gh/codecov/codecov-circleci-orb.png?style=badge)](https://circleci.com/gh/codecov/codecov-circleci-orb)
+

--- a/src/commands/upload.yml
+++ b/src/commands/upload.yml
@@ -24,7 +24,7 @@ parameters:
   upload_name:
     description: Custom defined name of the upload. Visible in Codecov UI
     type: string
-    default: ${CIRCLE_BUILD_NUM}
+    default: ""
   validate:
     description: Validate the uploader before uploading the codecov result.
     type: boolean

--- a/src/commands/upload.yml
+++ b/src/commands/upload.yml
@@ -50,7 +50,7 @@ steps:
   - run:
       name: Download Codecov Uploader
       command: <<include(scripts/download.sh)>>
-      when: always
+      when: << parameters.when >>
       environment:
         PARAM_VERSION: << parameters.version >>
   - when:

--- a/src/commands/upload.yml
+++ b/src/commands/upload.yml
@@ -13,7 +13,9 @@ parameters:
     default: ""
   flags:
     description: Flag the upload to group coverage metrics (e.g. unittests
-      | integration | ui,chrome)
+      | integration | ui,chrome). If the name of an environment
+      variable is provided as a flag then the value of that environment
+      environment variable will be used.
     type: string
     default: ""
   token:
@@ -48,7 +50,7 @@ steps:
   - run:
       name: Download Codecov Uploader
       command: <<include(scripts/download.sh)>>
-      when: << parameters.when >>
+      when: always
       environment:
         PARAM_VERSION: << parameters.version >>
   - when:

--- a/src/scripts/upload.sh
+++ b/src/scripts/upload.sh
@@ -6,6 +6,8 @@ chmod +x $codecov_filename
   set - "${@}" "-f" "${PARAM_FILE}"
 [ -n "${PARAM_XTRA_ARGS}" ] && \
   set - "${@}" "${PARAM_XTRA_ARGS}"
+[ -n "${PARAM_UPLOAD_NAME}" ] && \
+  PARAM_UPLOAD_NAME="${CIRCLE_BUILD_NUM}"
 # alpine doesn't allow for indirect expansion
 ./"$codecov_filename" \
   -Q "codecov-circleci-orb-3.2.5" \

--- a/src/scripts/upload.sh
+++ b/src/scripts/upload.sh
@@ -8,10 +8,25 @@ chmod +x $codecov_filename
   set - "${@}" "${PARAM_XTRA_ARGS}"
 [ -n "${PARAM_UPLOAD_NAME}" ] && \
   PARAM_UPLOAD_NAME="${CIRCLE_BUILD_NUM}"
+
+FLAGS=()
+IFS=',' read -ra FLAG_ARRAY <<< "$PARAM_FLAGS"
+for flag in "${FLAG_ARRAY[@]}"; do
+  eval e="\$$flag"
+  for param in "${e}" "${flag}"; do
+    if [ -n "${param}" ]; then
+      FLAGS+=("${param}")
+      break
+    fi
+  done
+done
+
+FINAL_FLAGS=$(IFS=',' ; echo "${FLAGS[*]}")
+
 # alpine doesn't allow for indirect expansion
 ./"$codecov_filename" \
   -Q "codecov-circleci-orb-3.2.5" \
   -t "$(eval echo \$$PARAM_TOKEN)" \
   -n "${PARAM_UPLOAD_NAME}" \
-  -F "${PARAM_FLAGS}" \
+  -F "${FINAL_FLAGS}" \
   ${@}


### PR DESCRIPTION
This PR fixes the `${CIRCLE_BUILD_NUM}` bug in the upload name.

This PR allows users to specify environment variables that specify the
flags to be used in the uploader.

Fixes: https://github.com/codecov/platform-team/issues/83