### PR TITLE
Add uploader option to exit with a non-zero

### DIFF
--- a/src/scripts/upload.sh
+++ b/src/scripts/upload.sh
@@ -12,4 +12,5 @@ chmod +x $codecov_filename
   -t "$(eval echo \$$PARAM_TOKEN)" \
   -n "${PARAM_UPLOAD_NAME}" \
   -F "${PARAM_FLAGS}" \
+  -Z \
   ${@}


### PR DESCRIPTION
This PR add uploader option to exit with non-zero to fail CircleCI codecov upload  job on codecov uploader error.