### PR TITLE
Fix CIRCLE_BUILD_NUM bug and allows users to specify env vars as flags

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -64,9 +64,9 @@ jobs:
           flags: alpine
           version: v0.1.0_8880
       - codecov/upload:
-          flags: frontend,ENV_VAR_FLAG
+          flags: string_flag,ENV_VAR_CONTAINING_FLAG
     environment:
-      ENV_VAR_FLAG: backend
+      ENV_VAR_CONTAINING_FLAG: env_var_flag
   test-linux:
     docker:
       - image: cimg/base:stable
@@ -85,9 +85,9 @@ jobs:
           flags: linux
           version: v0.1.0_8880
       - codecov/upload:
-          flags: frontend,ENV_VAR_FLAG
+          flags: string_flag,ENV_VAR_CONTAINING_FLAG
     environment:
-      ENV_VAR_FLAG: backend
+      ENV_VAR_CONTAINING_FLAG: env_var_flag
   test-macos:
     macos:
       xcode: 14.1
@@ -106,9 +106,9 @@ jobs:
           flags: macos
           version: v0.1.0_8880
       - codecov/upload:
-          flags: frontend,ENV_VAR_FLAG
+          flags: string_flag,ENV_VAR_CONTAINING_FLAG
     environment:
-      ENV_VAR_FLAG: backend
+      ENV_VAR_CONTAINING_FLAG: env_var_flag
   test-windows:
     executor:
       name: win/default
@@ -128,9 +128,9 @@ jobs:
           flags: windows
           version: v0.1.0_8880
       - codecov/upload:
-          flags: frontend,ENV_VAR_FLAG
+          flags: string_flag,ENV_VAR_CONTAINING_FLAG
     environment:
-      ENV_VAR_FLAG: backend
+      ENV_VAR_CONTAINING_FLAG: env_var_flag
 
 workflows:
   integration-tests_deploy:

--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -63,6 +63,10 @@ jobs:
           file: coverage/coverage-final.json
           flags: alpine
           version: v0.1.0_8880
+      - codecov/upload:
+          flags: frontend,ENV_VAR_FLAG
+    environment:
+      ENV_VAR_FLAG: backend
   test-linux:
     docker:
       - image: cimg/base:stable
@@ -80,6 +84,10 @@ jobs:
           file: coverage/coverage-final.json
           flags: linux
           version: v0.1.0_8880
+      - codecov/upload:
+          flags: frontend,ENV_VAR_FLAG
+    environment:
+      ENV_VAR_FLAG: backend
   test-macos:
     macos:
       xcode: 14.1
@@ -97,6 +105,10 @@ jobs:
           file: coverage/coverage-final.json
           flags: macos
           version: v0.1.0_8880
+      - codecov/upload:
+          flags: frontend,ENV_VAR_FLAG
+    environment:
+      ENV_VAR_FLAG: backend
   test-windows:
     executor:
       name: win/default
@@ -115,6 +127,10 @@ jobs:
           file: coverage/coverage-final.json
           flags: windows
           version: v0.1.0_8880
+      - codecov/upload:
+          flags: frontend,ENV_VAR_FLAG
+    environment:
+      ENV_VAR_FLAG: backend
 
 workflows:
   integration-tests_deploy:

--- a/src/commands/upload.yml
+++ b/src/commands/upload.yml
@@ -24,7 +24,7 @@ parameters:
   upload_name:
     description: Custom defined name of the upload. Visible in Codecov UI
     type: string
-    default: ${CIRCLE_BUILD_NUM}
+    default: ""
   validate:
     description: Validate the uploader before uploading the codecov result.
     type: boolean

--- a/src/commands/upload.yml
+++ b/src/commands/upload.yml
@@ -13,9 +13,8 @@ parameters:
     default: ""
   flags:
     description: Flag the upload to group coverage metrics (e.g. unittests
-      | integration | ui,chrome). If the name of an environment
-      variable is provided as a flag then the value of that environment
-      environment variable will be used.
+      | integration | ui,chrome). Flags can be input as strings or
+      environment variables.
     type: string
     default: ""
   token:

--- a/src/commands/upload.yml
+++ b/src/commands/upload.yml
@@ -50,7 +50,7 @@ steps:
   - run:
       name: Download Codecov Uploader
       command: <<include(scripts/download.sh)>>
-      when: always
+      when: << parameters.when >>
       environment:
         PARAM_VERSION: << parameters.version >>
   - when:

--- a/src/commands/upload.yml
+++ b/src/commands/upload.yml
@@ -13,7 +13,9 @@ parameters:
     default: ""
   flags:
     description: Flag the upload to group coverage metrics (e.g. unittests
-      | integration | ui,chrome)
+      | integration | ui,chrome). If the name of an environment
+      variable is provided as a flag then the value of that environment
+      environment variable will be used.
     type: string
     default: ""
   token:
@@ -48,7 +50,7 @@ steps:
   - run:
       name: Download Codecov Uploader
       command: <<include(scripts/download.sh)>>
-      when: << parameters.when >>
+      when: always
       environment:
         PARAM_VERSION: << parameters.version >>
   - when:

--- a/src/scripts/upload.sh
+++ b/src/scripts/upload.sh
@@ -6,6 +6,8 @@ chmod +x $codecov_filename
   set - "${@}" "-f" "${PARAM_FILE}"
 [ -n "${PARAM_XTRA_ARGS}" ] && \
   set - "${@}" "${PARAM_XTRA_ARGS}"
+[ -n "${PARAM_UPLOAD_NAME}" ] && \
+  PARAM_UPLOAD_NAME="${CIRCLE_BUILD_NUM}"
 # alpine doesn't allow for indirect expansion
 ./"$codecov_filename" \
   -Q "codecov-circleci-orb-3.2.5" \

--- a/src/scripts/upload.sh
+++ b/src/scripts/upload.sh
@@ -9,24 +9,27 @@ chmod +x $codecov_filename
 [ -n "${PARAM_UPLOAD_NAME}" ] && \
   PARAM_UPLOAD_NAME="${CIRCLE_BUILD_NUM}"
 
-FLAGS=()
-IFS=',' read -ra FLAG_ARRAY <<< "$PARAM_FLAGS"
-for flag in "${FLAG_ARRAY[@]}"; do
+FLAGS=""
+OLDIFS=$IFS;IFS=,
+for flag in $PARAM_FLAGS; do
   eval e="\$$flag"
   for param in "${e}" "${flag}"; do
     if [ -n "${param}" ]; then
-      FLAGS+=("${param}")
+      if [ -n "${FLAGS}" ]; then
+        FLAGS="${FLAGS},${param}"
+      else
+        FLAGS="${param}"
+      fi
       break
     fi
   done
 done
-
-FINAL_FLAGS=$(IFS=',' ; echo "${FLAGS[*]}")
+IFS=$OLDIFS
 
 # alpine doesn't allow for indirect expansion
 ./"$codecov_filename" \
   -Q "codecov-circleci-orb-3.2.5" \
   -t "$(eval echo \$$PARAM_TOKEN)" \
   -n "${PARAM_UPLOAD_NAME}" \
-  -F "${FINAL_FLAGS}" \
+  -F "${FLAGS}" \
   ${@}

--- a/src/scripts/upload.sh
+++ b/src/scripts/upload.sh
@@ -8,10 +8,25 @@ chmod +x $codecov_filename
   set - "${@}" "${PARAM_XTRA_ARGS}"
 [ -n "${PARAM_UPLOAD_NAME}" ] && \
   PARAM_UPLOAD_NAME="${CIRCLE_BUILD_NUM}"
+
+FLAGS=()
+IFS=',' read -ra FLAG_ARRAY <<< "$PARAM_FLAGS"
+for flag in "${FLAG_ARRAY[@]}"; do
+  eval e="\$$flag"
+  for param in "${e}" "${flag}"; do
+    if [ -n "${param}" ]; then
+      FLAGS+=("${param}")
+      break
+    fi
+  done
+done
+
+FINAL_FLAGS=$(IFS=',' ; echo "${FLAGS[*]}")
+
 # alpine doesn't allow for indirect expansion
 ./"$codecov_filename" \
   -Q "codecov-circleci-orb-3.2.5" \
   -t "$(eval echo \$$PARAM_TOKEN)" \
   -n "${PARAM_UPLOAD_NAME}" \
-  -F "${PARAM_FLAGS}" \
+  -F "${FINAL_FLAGS}" \
   ${@}


### PR DESCRIPTION
This PR fixes the ${CIRCLE_BUILD_NUM} bug in the upload name.

This PR allows users to specify environment variables that specify the
flags to be used in the uploader.

Fixes: https://github.com/codecov/platform-team/issues/83