### PR TITLE
download.sh now fetches aarch64 uploader build if necessary

### DIFF
--- a/src/scripts/download.sh
+++ b/src/scripts/download.sh
@@ -1,6 +1,14 @@
 family=$(uname -s | tr '[:upper:]' '[:lower:]')
 codecov_os="windows"
-[[ $family == "darwin" ]] && codecov_os="macos"
+
+if [[ $family == "darwin" ]]; then
+  arch=$(uname -m)
+  if [[ $arch == "arm64" ]]; then
+    codecov_os="aarch64"
+  else
+    codecov_os="macos"
+  fi
+fi
 
 [[ $family == "linux" ]] && codecov_os="linux"
 [[ $codecov_os == "linux" ]] && \


### PR DESCRIPTION
Fixes: https://github.com/codecov/feedback/issues/51