### PR TITLE
Handle dashes in flag names

### DIFF
--- a/src/scripts/upload.sh
+++ b/src/scripts/upload.sh
@@ -15,7 +15,10 @@ fi
 FLAGS=""
 OLDIFS=$IFS;IFS=,
 for flag in $PARAM_FLAGS; do
-  eval e="\$$flag"
+  e=""
+  if [[ -n ${!flag+x} ]]; then
+    eval e="\$$flag"
+  fi
   for param in "${e}" "${flag}"; do
     if [ -n "${param}" ]; then
       if [ -n "${FLAGS}" ]; then


### PR DESCRIPTION
This change adds a guard to a flag to ensure that the `eval` will produce a value. Without this change, a flag like `my-flag` will go through the `eval` as `$my-flag`. Since bash doesn't permit dashes in variable names, the resulting value will be `-flag`. Because this is a non-zero length, the first iteration through the for loop on `${e}` will set in `FLAGS`, then break out. This leads to the improper result of `FLAGS` having `-flag` instead of the desired value of `my-flag`.

By testing that flag will produce a value before trying `eval`, we can be sure that the first loop iteration will proceed and allow the processing of the second iteration on `${flag}` (which will correctly capture `my-flag` in our example).

`${!flag+x}` is used for indirect variable expansion. If flag contains the name of a variable, `${!flag}` will expand to the value of that variable. The +x part ensures that the expression evaluates to true if the variable exists, even if it's empty.

This fixes #175.