### PR TITLE
Update report_type docstring

### DIFF
--- a/src/commands/upload.yml
+++ b/src/commands/upload.yml
@@ -118,7 +118,7 @@ parameters:
     type: string
     default: ""
   report_type:
-    description: The type of file to upload, coverage by default. Possible values are "testing", "coverage".
+    description: The type of file to upload, coverage by default. Possible values are "test_results", "coverage".
     type: string
     default: "coverage"
   sha:


### PR DESCRIPTION
The options available on the codecov CLI are `coverage` and `test_results`, so I believe that should be mirrored here.

![image](https://github.com/user-attachments/assets/4a44a320-785f-48d1-a2e4-ce8209fcc43a)
