### PR TITLE
chore(release): 6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "codecov-circleci-orb",
-  "version": "5.4.3",
+  "version": "6.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "codecov-circleci-orb",
-      "version": "5.4.3",
+      "version": "6.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/mocha": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "codecov-circleci-orb",
-  "version": "5.4.3",
+  "version": "6.0.0",
   "description": "Codecov CircleCI Orb",
   "main": "index.js",
   "devDependencies": {

--- a/src/commands/upload.yml
+++ b/src/commands/upload.yml
@@ -185,6 +185,7 @@ steps:
         CODECOV_BRANCH: << parameters.branch >>
         CODECOV_BUILD: << parameters.build >>
         CODECOV_BUILD_URL: << parameters.build_url >>
+        CODECOV_CLI_TYPE: codecov-cli
         CODECOV_CODE: << parameters.code >>
         CODECOV_DIR: << parameters.dir >>
         CODECOV_DISABLE_FILE_FIXES: << parameters.disable_file_fixes >>

--- a/src/dist/download.sh
+++ b/src/dist/download.sh
@@ -57,11 +57,17 @@ then
   fi
 elif [ "$CODECOV_USE_PYPI" == "true" ];
 then
-  if ! pip install codecov-cli"$([ "$CODECOV_VERSION" == "latest" ] && echo "" || echo "==$CODECOV_VERSION" )"; then
+  if ! pip install "${CODECOV_CLI_TYPE}$([ "$CODECOV_VERSION" == "latest" ] && echo "" || echo "==$CODECOV_VERSION")"; then
     exit_if_error "Could not install via pypi."
     exit
   fi
-  CODECOV_COMMAND="codecovcli"
+  if [[ "$CODECOV_CLI_TYPE" == "codecov-cli" ]]; then
+    CODECOV_COMMAND="codecovcli"
+  elif [[ "$CODECOV_CLI_TYPE" == "sentry-prevent-cli" ]]; then
+    CODECOV_COMMAND="sentry-prevent-cli"
+  else
+    CODECOV_COMMAND="${CODECOV_CLI_TYPE}"
+  fi
 else
   if [ -n "$CODECOV_OS" ];
   then
@@ -78,7 +84,7 @@ else
     say "$g==>$x Detected $b${CODECOV_OS}$x"
   fi
 
-  CODECOV_FILENAME="codecov"
+  CODECOV_FILENAME="${CODECOV_CLI_TYPE%-cli}"
   [[ $CODECOV_OS == "windows" ]] && CODECOV_FILENAME+=".exe"
   CODECOV_COMMAND="./$CODECOV_FILENAME"
   [[ $CODECOV_OS == "macos" ]]  && \

--- a/src/dist/set_defaults.sh
+++ b/src/dist/set_defaults.sh
@@ -46,10 +46,11 @@ r="\033[0;31m"  # errors
 x="\033[0m"
 retry="--retry 5 --retry-delay 2"
 
-CODECOV_WRAPPER_VERSION="0.2.6"
+CODECOV_WRAPPER_VERSION="0.2.9"
 CODECOV_VERSION="${CODECOV_VERSION:-latest}"
 CODECOV_FAIL_ON_ERROR="${CODECOV_FAIL_ON_ERROR:-false}"
 CODECOV_RUN_CMD="${CODECOV_RUN_CMD:-upload-coverage}"
+CODECOV_CLI_TYPE=${CODECOV_CLI_TYPE:-"codecov-cli"}
 
 say "     _____          _
     / ____|        | |
@@ -59,4 +60,9 @@ say "     _____          _
     \\_____\\___/ \\__,_|\\___|\\___\\___/ \\_/
                            $r Wrapper-$CODECOV_WRAPPER_VERSION$x
                            "
+
+if [[ "$CODECOV_CLI_TYPE" != "codecov-cli" && "$CODECOV_CLI_TYPE" != "sentry-prevent-cli" ]]; then
+  echo "Invalid CODECOV_CLI_TYPE: '$CODECOV_CLI_TYPE'. Must be 'codecov-cli' or 'sentry-prevent-cli'"
+  exit 1
+fi
 env | grep -io "CODECOV_.*=" | tr "=" " " | while read -r val; do echo "export $val=$(eval echo \"\$$val\")"; done > ./codecov_envs

--- a/src/dist/set_defaults.sh
+++ b/src/dist/set_defaults.sh
@@ -50,7 +50,7 @@ CODECOV_WRAPPER_VERSION="0.2.9"
 CODECOV_VERSION="${CODECOV_VERSION:-latest}"
 CODECOV_FAIL_ON_ERROR="${CODECOV_FAIL_ON_ERROR:-false}"
 CODECOV_RUN_CMD="${CODECOV_RUN_CMD:-upload-coverage}"
-export CODECOV_CLI_TYPE=${CODECOV_CLI_TYPE:-"codecov-cli"}
+CODECOV_CLI_TYPE=${CODECOV_CLI_TYPE:-"codecov-cli"}
 
 say "     _____          _
     / ____|        | |

--- a/src/dist/set_defaults.sh
+++ b/src/dist/set_defaults.sh
@@ -50,7 +50,7 @@ CODECOV_WRAPPER_VERSION="0.2.9"
 CODECOV_VERSION="${CODECOV_VERSION:-latest}"
 CODECOV_FAIL_ON_ERROR="${CODECOV_FAIL_ON_ERROR:-false}"
 CODECOV_RUN_CMD="${CODECOV_RUN_CMD:-upload-coverage}"
-CODECOV_CLI_TYPE=${CODECOV_CLI_TYPE:-"codecov-cli"}
+export CODECOV_CLI_TYPE=${CODECOV_CLI_TYPE:-"codecov-cli"}
 
 say "     _____          _
     / ____|        | |

--- a/src/dist/validate.sh
+++ b/src/dist/validate.sh
@@ -49,8 +49,12 @@ retry="--retry 5 --retry-delay 2"
 if [ "$CODECOV_SKIP_VALIDATION" == "true" ] || [ -n "$CODECOV_BINARY" ] || [ "$CODECOV_USE_PYPI" == "true" ];
 then
   say "$r==>$x Bypassing validation..."
+  if [ "$CODECOV_SKIP_VALIDATION" == "true" ];
+  then
+    chmod +x "$CODECOV_COMMAND"
+  fi
 else
-  echo "$(curl -s https://keybase.io/codecovsecurity/pgp_keys.asc)" | \
+  echo "$(curl -s https://keybase.io/codecovsecops/pgp_keys.asc)" | \
     gpg --no-default-keyring --import
   # One-time step
   say "$g==>$x Verifying GPG signature integrity"
@@ -82,11 +86,12 @@ fi
 if [ -n "$CODECOV_BINARY_LOCATION" ];
 then
   mkdir -p "$CODECOV_BINARY_LOCATION" && mv "$CODECOV_FILENAME" $_
-  say "$g==>$x Codecov binary moved to ${CODECOV_BINARY_LOCATION}"
+  say "$g==>$x ${CODECOV_CLI_TYPE} binary moved to ${CODECOV_BINARY_LOCATION}"
 fi
 
 if [ "$CODECOV_DOWNLOAD_ONLY" = "true" ];
 then
-  say "$g==>$x Codecov download only called. Exiting..."
+  say "$g==>$x ${CODECOV_CLI_TYPE} download only called. Exiting..."
+  exit
 fi
 env | grep -io "CODECOV_.*=" | tr "=" " " | while read -r val; do echo "export $val=$(eval echo \"\$$val\")"; done > ./codecov_envs


### PR DESCRIPTION
## Summary
- **Bump wrapper submodule** `src/scripts` `9fa0f80` → `bad8df5` (latest `codecov/wrapper` `main`), which fetches the Codecov Uploader PGP key from the `codecovsecops` Keybase account.
- **Major version bump** `5.4.3` → `6.0.0` in `package.json` and `package-lock.json`.

## Why a submodule bump was needed
`git submodule update --init --recursive` only checks out the commit pinned in this repo's tree, not the tip of the wrapper's `main`. This records the new pointer (`bad8df5`) that everyone/CI will now check out.

## Test plan
- [ ] `git submodule update --init --recursive` checks out `bad8df5` under `src/scripts`.
- [ ] Orb runs end-to-end: wrapper imports the PGP key from `codecovsecops` and verifies the CLI `SHA256SUM` signature.
- [ ] `make deploy` tags `v6.0.0` after merge.

Made with [Cursor](https://cursor.com)